### PR TITLE
MFASelectionsResponse.getSelections() needs to be public

### DIFF
--- a/src/main/java/com/plaid/client/response/MfaResponse.java
+++ b/src/main/java/com/plaid/client/response/MfaResponse.java
@@ -77,7 +77,7 @@ public abstract class MfaResponse extends PlaidUserResponse {
     	private Selection[] selections;
     	
     	@JsonProperty("mfa")
-    	private Selection[] getSelections() {
+    	public Selection[] getSelections() {
     		return selections;
     	}
     	


### PR DESCRIPTION
It seems the getter method for MFA selections was marked as private, rea.lly needs to be public for any kind of practical use.