### PR TITLE
Implementing the Plaid Auth MFA Device Selection API 

### DIFF
--- a/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
@@ -3,6 +3,7 @@ package com.plaid.client;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.plaid.client.response.MfaResponse;
 import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -91,6 +92,31 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
     public AccountsResponse mfaAuthStep(String mfa, String type) throws PlaidMfaException {
 
         return handleMfa("/auth/step", mfa, type, AccountsResponse.class);
+    }
+
+    @Override
+    public AccountsResponse mfaAuthDeviceSelection( MfaResponse.DeviceType device, String type) throws PlaidMfaException {
+
+        if (StringUtils.isEmpty(accessToken)) {
+            throw new PlaidClientsideException("No accessToken set");
+        }
+
+        if (device == null){
+            throw new PlaidClientsideException("No device selected");
+        }
+
+        Map<String, Object> requestParams = new HashMap<String, Object>();
+        requestParams.put("type", type);
+
+        if (device.getMask() != null){
+            HashMap<String, String> mask= new HashMap<String, String>();
+            mask.put("mask", device.getMask());
+            HashMap<String, Object> sendMethod = new HashMap<String, Object>();
+            sendMethod.put("send_method", mask);
+            requestParams.put("options", sendMethod);
+        }
+
+        return handlePost("/auth/step", requestParams, AccountsResponse.class);
     }
     
     @Override
@@ -228,6 +254,7 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
         }
 
         Map<String, Object> requestParams = new HashMap<String, Object>();
+
         requestParams.put("mfa", mfa);
 
         if (type != null) {

--- a/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
@@ -95,26 +95,47 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
     }
 
     @Override
-    public AccountsResponse mfaAuthDeviceSelection( MfaResponse.DeviceType device, String type) throws PlaidMfaException {
+    public AccountsResponse mfaAuthDeviceSelectionByDeviceType(String deviceType, String type) throws PlaidMfaException {
 
         if (StringUtils.isEmpty(accessToken)) {
             throw new PlaidClientsideException("No accessToken set");
         }
 
-        if (device == null){
+        if (StringUtils.isEmpty(deviceType)){
             throw new PlaidClientsideException("No device selected");
         }
 
         Map<String, Object> requestParams = new HashMap<String, Object>();
         requestParams.put("type", type);
 
-        if (device.getMask() != null){
-            HashMap<String, String> mask= new HashMap<String, String>();
-            mask.put("mask", device.getMask());
-            HashMap<String, Object> sendMethod = new HashMap<String, Object>();
-            sendMethod.put("send_method", mask);
-            requestParams.put("options", sendMethod);
+        HashMap<String, String> mask = new HashMap<String, String>();
+        mask.put("type", deviceType);
+        HashMap<String, Object> sendMethod = new HashMap<String, Object>();
+        sendMethod.put("send_method", mask);
+        requestParams.put("options", sendMethod);
+
+        return handlePost("/auth/step", requestParams, AccountsResponse.class);
+    }
+
+    @Override
+    public AccountsResponse mfaAuthDeviceSelectionByDeviceMask(String deviceMask, String type) throws PlaidMfaException {
+
+        if (StringUtils.isEmpty(accessToken)) {
+            throw new PlaidClientsideException("No accessToken set");
         }
+
+        if (StringUtils.isEmpty(deviceMask)) {
+            throw new PlaidClientsideException("No device selected");
+        }
+
+        Map<String, Object> requestParams = new HashMap<String, Object>();
+        requestParams.put("type", type);
+
+        HashMap<String, String> mask = new HashMap<String, String>();
+        mask.put("mask", deviceMask);
+        HashMap<String, Object> sendMethod = new HashMap<String, Object>();
+        sendMethod.put("send_method", mask);
+        requestParams.put("options", sendMethod);
 
         return handlePost("/auth/step", requestParams, AccountsResponse.class);
     }

--- a/src/main/java/com/plaid/client/PlaidUserClient.java
+++ b/src/main/java/com/plaid/client/PlaidUserClient.java
@@ -28,7 +28,9 @@ public interface PlaidUserClient {
 
     AccountsResponse mfaAuthStep(String mfa, String type) throws PlaidMfaException;
 
-    AccountsResponse mfaAuthDeviceSelection(MfaResponse.DeviceType device, String type) throws PlaidMfaException;
+    AccountsResponse mfaAuthDeviceSelectionByDeviceType(String deviceType, String type) throws PlaidMfaException;
+
+    AccountsResponse mfaAuthDeviceSelectionByDeviceMask(String deviceMask, String type) throws PlaidMfaException;
 
     TransactionsResponse updateTransactions();
 

--- a/src/main/java/com/plaid/client/PlaidUserClient.java
+++ b/src/main/java/com/plaid/client/PlaidUserClient.java
@@ -9,6 +9,7 @@ import com.plaid.client.request.InfoOptions;
 import com.plaid.client.response.AccountsResponse;
 import com.plaid.client.response.InfoResponse;
 import com.plaid.client.response.MessageResponse;
+import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.TransactionsResponse;
 
 public interface PlaidUserClient {
@@ -26,7 +27,9 @@ public interface PlaidUserClient {
     AccountsResponse achAuth(Credentials credentials, String type, ConnectOptions connectOptions) throws PlaidMfaException;
 
     AccountsResponse mfaAuthStep(String mfa, String type) throws PlaidMfaException;
-    
+
+    AccountsResponse mfaAuthDeviceSelection(MfaResponse.DeviceType device, String type) throws PlaidMfaException;
+
     TransactionsResponse updateTransactions();
 
     TransactionsResponse updateTransactions(GetOptions options);


### PR DESCRIPTION
Added 2 methods to PlaidUserClient, one for using the device mask, another for the device type.  Done to match Plaid's support of both methods.

I tried to make a 1 method solution at first, but decided for usability reasons it was best to implement separate methods to do this.