### PR TITLE
getAllCategories had wrong resource name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /target
 .idea
 plaid-java.iml
+*.ipr
+*.iws
+

--- a/src/main/java/com/plaid/client/DefaultPlaidPublicClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidPublicClient.java
@@ -38,7 +38,7 @@ public class DefaultPlaidPublicClient implements PlaidPublicClient {
     @Override
     public CategoriesResponse getAllCategories() {
         
-        PlaidHttpRequest request = new PlaidHttpRequest("/category");
+        PlaidHttpRequest request = new PlaidHttpRequest("/categories");
         
         HttpResponseWrapper<Category[]> response = httpDelegate.doGet(request, Category[].class);
 

--- a/src/test/java/com/plaid/client/PlaidPublicClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidPublicClientTest.java
@@ -19,14 +19,14 @@ public class PlaidPublicClientTest {
     private HttpDelegate httpDelegate;
     private PlaidPublicClient plaidPublicClient;
     
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8089);
+    //@Rule
+    //public WireMockRule wireMockRule = new WireMockRule(8089);
 
     @Before
     public  void setup() {
         httpClient = HttpClients.createDefault();
-        httpDelegate = new ApacheHttpClientHttpDelegate("http://localhost:8089", httpClient);
-        //HttpDelegate httpDelegate = new ApacheHttpClientHttpDelegate("https://tartan.plaid.com", httpClient);
+        //httpDelegate = new ApacheHttpClientHttpDelegate("http://localhost:8089", httpClient);
+        HttpDelegate httpDelegate = new ApacheHttpClientHttpDelegate("https://tartan.plaid.com", httpClient);
         plaidPublicClient = new DefaultPlaidPublicClient.Builder()
                 .withHttpDelegate(httpDelegate)
                 .build();


### PR DESCRIPTION
When using the live test system, the getAllCategories test failed - it was using "category" instead of "categories".
