### PR TITLE
Add /exchange_token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,42 @@ Plaid-java is available at [Maven Central](https://search.maven.org/#search%7Cga
 ### Basic Usage
 
 ```java
-        
+
 // Add Amex user, get 30 days of transactions
-        
+
 PlaidUserClient plaidUserClient = PlaidClients.testUserClient("test_id", "test_secret");
 Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
 TransactionsResponse response = plaidUserClient.addUser(testCredentials, "amex", "test@test.com", null);
 
 List<Transaction> transactions = response.getTransactions();
-        
-        
+
+
 // Get all Categories
-        
+
 PlaidPublicClient plaidPublicClient = PlaidClients.testPublicClient();
 CategoriesResponse categoriesResponse = plaidPublicClient.getAllCategories();
-        
+
 List<Category> categories = categoriesResponse.getCategories();
 ```
 
 Check the Junit test classes for examples of more use cases.
+
+### Exchange a Plaid Link public_token for an API access_token
+
+```java
+// Initialize a Plaid client with your client_id and secret
+PlaidUserClient plaidUserClient = PlaidClients.testUserClient("test_id", "test_secret");
+
+// Exchange the Link public_token ("test,bofa,connected") for an API access_token
+PlaidUserResponse response = plaidUserClient.exchangeToken("test,bofa,connected");
+
+// Initialize the user with the access_token returned by the exchangeToken call
+plaidUserClient.setAccessToken(response.getAccessToken());
+
+// Pull accounts for the user
+// Note: This assumes you are using Link with the "auth" product
+AccountsResponse response = plaidUserClient.updateAuth();
+```
 
 ### Dependencies
 

--- a/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
@@ -54,6 +54,14 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
     }
 
     @Override
+    public PlaidUserResponse exchangeToken(String publicToken) {
+        Map<String, Object> requestParams = new HashMap<String, Object>();
+        requestParams.put("public_token", publicToken);
+
+        return handlePost("/exchange_token", requestParams, PlaidUserResponse.class);
+    }
+
+    @Override
     public TransactionsResponse addUser(Credentials credentials, String type, String email, ConnectOptions connectOptions) throws PlaidMfaException {
 
         Map<String, Object> requestParams = new HashMap<String, Object>();
@@ -133,7 +141,7 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
 
         return handlePost("/auth/step", requestParams, AccountsResponse.class);
     }
-    
+
     @Override
     public TransactionsResponse updateTransactions() {
 
@@ -151,13 +159,13 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
         return body;
 
     }
-    
+
     @Override
     public TransactionsResponse updateTransactions(GetOptions options) {
     	if (StringUtils.isEmpty(accessToken)) {
             throw new PlaidClientsideException("No accessToken set");
         }
-        
+
         Map<String, Object> requestParams = new HashMap<String, Object>();
         if (options != null) {
         	requestParams.put("options", options);
@@ -165,13 +173,13 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
 
         return handlePost("/connect/get", requestParams, TransactionsResponse.class);
     }
-    
+
     @Override
     public AccountsResponse updateAuth() {
     	if (StringUtils.isEmpty(accessToken)) {
             throw new PlaidClientsideException("No accessToken set");
         }
-        
+
         Map<String, Object> requestParams = new HashMap<String, Object>();
 
         return handlePost("/auth/get", requestParams, AccountsResponse.class);
@@ -246,29 +254,29 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
         }
 
     	Map<String, Object> requestParams = new HashMap<String, Object>();
-    	
+
     	return handlePost("/balance", requestParams, AccountsResponse.class);
     }
 
     @Override
     public TransactionsResponse addProduct(String product, ConnectOptions options) {
-    	
+
     	if (StringUtils.isEmpty(accessToken)) {
             throw new PlaidClientsideException("No accessToken set");
         }
 
     	Map<String, Object> requestParams = new HashMap<String, Object>();
     	requestParams.put("upgrade_to", product);
-    	
+
     	requestParams.put("login",true);
-    	
+
     	if (options != null) {
     		requestParams.put("options", options);
     	}
-    	
+
     	return handlePost("/upgrade", requestParams, TransactionsResponse.class);
     }
-    
+
     @Override
     public InfoResponse info(Credentials credentials, String type, InfoOptions options) {
     	 Map<String, Object> requestParams = new HashMap<String, Object>();
@@ -278,7 +286,7 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
 
          return handlePost("/info", requestParams, InfoResponse.class);
     }
-    
+
     private <T extends PlaidUserResponse> T handleMfa(String path, String mfa, String type, Class<T> returnTypeClass) throws PlaidMfaException {
 
         if (StringUtils.isEmpty(accessToken)) {

--- a/src/main/java/com/plaid/client/PlaidUserClient.java
+++ b/src/main/java/com/plaid/client/PlaidUserClient.java
@@ -11,12 +11,15 @@ import com.plaid.client.response.InfoResponse;
 import com.plaid.client.response.MessageResponse;
 import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.TransactionsResponse;
+import com.plaid.client.response.PlaidUserResponse;
 
 public interface PlaidUserClient {
 
     void setAccessToken(String accesstoken);
 
     String getAccessToken();
+
+    PlaidUserResponse exchangeToken(String publicToken);
 
     TransactionsResponse addUser(Credentials credentials, String type, String email, ConnectOptions connectOptions) throws PlaidMfaException;
 
@@ -33,7 +36,7 @@ public interface PlaidUserClient {
     TransactionsResponse updateTransactions();
 
     TransactionsResponse updateTransactions(GetOptions options);
-    
+
     TransactionsResponse updateCredentials(Credentials credentials, String type);
 
     TransactionsResponse updateWebhook(String webhook);
@@ -43,9 +46,9 @@ public interface PlaidUserClient {
     MessageResponse deleteUser();
 
     AccountsResponse checkBalance();
-    
+
     InfoResponse info(Credentials credentials, String type, InfoOptions options);
-    
+
     TransactionsResponse addProduct(String product, ConnectOptions options);
 
     HttpDelegate getHttpDelegate();

--- a/src/test/java/com/plaid/client/PlaidUserClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidUserClientTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.plaid.client.exception.PlaidMfaException;
+import com.plaid.client.exception.PlaidServersideException;
 import com.plaid.client.http.ApacheHttpClientHttpDelegate;
 import com.plaid.client.http.HttpDelegate;
 import com.plaid.client.request.ConnectOptions;
@@ -21,13 +22,15 @@ import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.MfaResponse.DeviceChoiceMfaResponse;
 import com.plaid.client.response.MfaResponse.DeviceListMfaResponse;
 import com.plaid.client.response.TransactionsResponse;
+import com.plaid.client.response.PlaidUserResponse;
+import com.plaid.client.response.ErrorResponse;
 
 public class PlaidUserClientTest {
 
     private CloseableHttpClient httpClient;
     private HttpDelegate httpDelegate;
     private PlaidUserClient plaidUserClient;
-    
+
    // @Rule
    // public WireMockRule wireMockRule = new WireMockRule(8089);
 
@@ -48,23 +51,23 @@ public class PlaidUserClientTest {
     public void testAddAmexUser() {
         Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
         TransactionsResponse response = plaidUserClient.addUser(testCredentials, "amex", "test@test.com", null);
-        
+
         assertEquals("test_amex",response.getAccessToken());
         assertTrue(response.getAccounts().size() > 0);
         assertTrue(response.getTransactions().size() > 0);
-    }    
+    }
 
     @Test
     public void testAddChaseUserListMfa() {
-        
+
         try {
             Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
             ConnectOptions options = new ConnectOptions();
             options.setList(true);
-            TransactionsResponse response = plaidUserClient.addUser(testCredentials, "chase", "test@test.com", options);                        
+            TransactionsResponse response = plaidUserClient.addUser(testCredentials, "chase", "test@test.com", options);
         }
         catch (PlaidMfaException e) {
-            
+
             MfaResponse mfaResponse = e.getMfaResponse();
             assertNotNull(mfaResponse);
             assertEquals("list", mfaResponse.getType());
@@ -72,100 +75,118 @@ public class PlaidUserClientTest {
             assertTrue(mfaResponse instanceof DeviceListMfaResponse);
         }
     }
-       
+
     @Test
     public void testAddChaseUserWithMfaStep() {
-        
+
         try {
             Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
             ConnectOptions options = new ConnectOptions();
             options.setLogin(true);
-            plaidUserClient.addUser(testCredentials, "chase", "test@test.com", options);                                  
+            plaidUserClient.addUser(testCredentials, "chase", "test@test.com", options);
         }
         catch (PlaidMfaException e) {
-            
+
             MfaResponse mfaResponse = e.getMfaResponse();
             assertNotNull(mfaResponse);
             assertEquals("test_chase", mfaResponse.getAccessToken());
             assertEquals("device", mfaResponse.getType());
             assertTrue(mfaResponse instanceof DeviceChoiceMfaResponse);
-            
+
             TransactionsResponse response = plaidUserClient.mfaConnectStep("1234", "chase");
             assertEquals("test_chase",response.getAccessToken());
             assertTrue(response.getAccounts().size() > 0);
-            assertTrue(response.getTransactions().size() > 0);            
+            assertTrue(response.getTransactions().size() > 0);
         }
     }
-    
-    
+
+
     @Test
     public void testInfoWellsFargo() {
     	Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
         InfoResponse response = plaidUserClient.info(testCredentials, "wells", null);
-        
+
         assertEquals("test_wells",response.getAccessToken());
         assertNotNull(response.getInfo());
     }
-    
+
     @Test
     public void testUpdateTransactions() {
 
         plaidUserClient.setAccessToken("test_wells");
         TransactionsResponse response = plaidUserClient.updateTransactions();
-        
+
         assertEquals("test_wells",response.getAccessToken());
         assertTrue(response.getAccounts().size() > 0);
         assertTrue(response.getTransactions().size() > 0);
     }
-    
+
     @Test
     public void testUpdateAuth() {
 
         plaidUserClient.setAccessToken("test_wells");
         AccountsResponse response = plaidUserClient.updateAuth();
-        
+
         assertEquals("test_wells",response.getAccessToken());
         assertTrue(response.getAccounts().size() > 0);
         assertNotNull(response.getAccounts().get(0).getNumbers());
     }
-    
+
     @Test
     public void testCheckBalance() {
-    	
+
     	plaidUserClient.setAccessToken("test_wells");
     	AccountsResponse response = plaidUserClient.checkBalance();
     	assertEquals("test_wells",response.getAccessToken());
         assertTrue(response.getAccounts().size() > 0);
     }
-    
+
     @Test
     public void testAddProduct() {
-    	
+
     	plaidUserClient.setAccessToken("test_wells");
     	AccountsResponse response = plaidUserClient.addProduct("auth", null);
     	assertEquals("test_wells",response.getAccessToken());
-        assertTrue(response.getAccounts().size() > 0);	
+        assertTrue(response.getAccounts().size() > 0);
     }
-    
+
     @Test
     // Not testable with WireMock since HTTP PATCH is unsupported
     public void testUpdateCredentials() {
         Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
         plaidUserClient.setAccessToken("test_amex");
         TransactionsResponse response = plaidUserClient.updateCredentials(testCredentials, "amex");
-        
+
         assertEquals("test_amex",response.getAccessToken());
         assertTrue(response.getAccounts().size() > 0);
 //        assertTrue(response.getTransactions().size() > 0);
     }
-    
+
     @Test
     public void testDeleteUser() {
         plaidUserClient.setAccessToken("test_citi");
         MessageResponse response = plaidUserClient.deleteUser();
-        
+
         assertEquals("Successfully removed from system", response.getMessage());
     }
-    
-   
+
+    @Test
+    public void testExchangeTokenSuccess() {
+        PlaidUserResponse response = plaidUserClient.exchangeToken("test,chase,connected");
+
+        assertEquals("test_chase", response.getAccessToken());
+    }
+
+    @Test
+    public void testExchangeTokenFailure() {
+        try {
+            PlaidUserResponse response = plaidUserClient.exchangeToken("invalid_public_token");
+        } catch (PlaidServersideException e) {
+            assertEquals(e.getHttpStatusCode(), 401);
+            assertEquals(e.getErrorResponse().getCode(), Integer.valueOf(1106));
+            assertEquals(e.getErrorResponse().getMessage(), "bad public_token");
+        }
+    }
+
+
 }


### PR DESCRIPTION
Closes https://github.com/plaid/plaid-java/issues/30.

Ping @erimag - if you have the time, I'd appreciate it if you could take a look at this! I've tried to stick to the library conventions as much as possible. One thought - I used the existing `PlaidUserResponse` because it fit well (the only field returned from the `/exchange_token` endpoint is `access_token`) but we could also create `ExchangeTokenResponse` and `ExchangeToken` classes, though that feels a bit unnecessary.

It also looks like my global config settings for git caused a bit of EOL normalization. I'm happy to update the pull request to remove that if you have objections.  The pull request is best viewed with [?w=1](https://github.com/plaid/plaid-java/pull/31/files?w=1).