### PR TITLE
Addeded message to PlaidServersideException

### DIFF
--- a/src/main/java/com/plaid/client/exception/PlaidServersideException.java
+++ b/src/main/java/com/plaid/client/exception/PlaidServersideException.java
@@ -8,6 +8,7 @@ public class PlaidServersideException extends RuntimeException {
     private int httpStatusCode;
     
     public PlaidServersideException(ErrorResponse errorResponse, int httpStatusCode) {
+        super(String.format("%s: %s", httpStatusCode, errorResponse != null ? errorResponse.getMessage() : null));
         this.errorResponse = errorResponse;
         this.httpStatusCode = httpStatusCode;
     }

--- a/src/test/java/com/plaid/client/exception/PlaidServersideExceptionTest.java
+++ b/src/test/java/com/plaid/client/exception/PlaidServersideExceptionTest.java
@@ -1,0 +1,31 @@
+package com.plaid.client.exception;
+
+import com.plaid.client.response.ErrorResponse;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PlaidServersideExceptionTest {
+
+    @Test
+    public void setsExceptionMessage() throws Exception {
+
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setMessage("Bad Request");
+
+        PlaidServersideException exception = new PlaidServersideException(errorResponse, HttpStatus.SC_BAD_REQUEST);
+
+        assertEquals("400: Bad Request", exception.getMessage());
+
+    }
+
+    @Test
+    public void setsExceptionMessageForNullErrorResponse() throws Exception {
+
+        PlaidServersideException exception = new PlaidServersideException(null, HttpStatus.SC_BAD_REQUEST);
+
+        assertEquals("400: null", exception.getMessage());
+
+    }
+}


### PR DESCRIPTION
Added a message to `PlaidServersideException` since standard exception logging does not show what really went wrong since message is `null`.

```java
c.p.c.e.PlaidServersideException: null
	at c.p.c.h.ApacheHttpClientHttpDelegate.handleResponse(ApacheHttpClientHttpDelegate.java:213) ~[plaid-java-0.2.8.jar!/:0.2.8]
	at c.p.c.h.ApacheHttpClientHttpDelegate.doPost(ApacheHttpClientHttpDelegate.java:94)
	at c.p.c.DefaultPlaidUserClient.handlePost(DefaultPlaidUserClient.java:262)
	at c.p.c.DefaultPlaidUserClient.checkBalance(DefaultPlaidUserClient.java:185)
	at c.q.d.i.p.h.CheckBalance.run(CheckBalance.java:33) ~[gamma-qapital-client-api.jar!/:0.0.1-SNAPSHOT]
	... 23 common frames omitted
```