### PR TITLE
Use access token and GET for Info request

### DIFF
--- a/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
@@ -278,13 +278,20 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
     }
 
     @Override
-    public InfoResponse info(Credentials credentials, String type, InfoOptions options) {
-    	 Map<String, Object> requestParams = new HashMap<String, Object>();
-         requestParams.put("credentials", credentials);
-         requestParams.put("type", type);
-         requestParams.put("options", options);
+    public InfoResponse info() {
 
-         return handlePost("/info", requestParams, InfoResponse.class);
+        if (StringUtils.isEmpty(accessToken)) {
+            throw new PlaidClientsideException("No accessToken set");
+        }
+
+        PlaidHttpRequest request = new PlaidHttpRequest("/info", authenticationParams(), timeout);
+
+        HttpResponseWrapper<InfoResponse> response =
+                httpDelegate.doGet(request, InfoResponse.class);
+
+        InfoResponse body = response.getResponseBody();
+        setAccessToken(body.getAccessToken());
+        return body;
     }
 
     private <T extends PlaidUserResponse> T handleMfa(String path, String mfa, String type, Class<T> returnTypeClass) throws PlaidMfaException {

--- a/src/main/java/com/plaid/client/PlaidUserClient.java
+++ b/src/main/java/com/plaid/client/PlaidUserClient.java
@@ -47,7 +47,7 @@ public interface PlaidUserClient {
 
     AccountsResponse checkBalance();
 
-    InfoResponse info(Credentials credentials, String type, InfoOptions options);
+    InfoResponse info();
 
     TransactionsResponse addProduct(String product, ConnectOptions options);
 

--- a/src/test/java/com/plaid/client/PlaidUserClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidUserClientTest.java
@@ -104,7 +104,7 @@ public class PlaidUserClientTest {
     @Test
     public void testInfoWellsFargo() {
     	Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
-        InfoResponse response = plaidUserClient.info(testCredentials, "wells", null);
+        InfoResponse response = plaidUserClient.info();
 
         assertEquals("test_wells",response.getAccessToken());
         assertNotNull(response.getInfo());

--- a/src/test/java/com/plaid/client/PlaidUserClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidUserClientTest.java
@@ -103,7 +103,7 @@ public class PlaidUserClientTest {
 
     @Test
     public void testInfoWellsFargo() {
-    	Credentials testCredentials = new Credentials("plaid_test", "plaid_good");
+    	plaidUserClient.setAccessToken("test_wells");
         InfoResponse response = plaidUserClient.info();
 
         assertEquals("test_wells",response.getAccessToken());
@@ -167,7 +167,7 @@ public class PlaidUserClientTest {
         plaidUserClient.setAccessToken("test_citi");
         MessageResponse response = plaidUserClient.deleteUser();
 
-        assertEquals("Successfully removed from system", response.getMessage());
+        assertEquals("Successfully removed from your account", response.getMessage());
     }
 
     @Test
@@ -183,8 +183,8 @@ public class PlaidUserClientTest {
             PlaidUserResponse response = plaidUserClient.exchangeToken("invalid_public_token");
         } catch (PlaidServersideException e) {
             assertEquals(e.getHttpStatusCode(), 401);
-            assertEquals(e.getErrorResponse().getCode(), Integer.valueOf(1106));
-            assertEquals(e.getErrorResponse().getMessage(), "bad public_token");
+            assertEquals(e.getErrorResponse().getCode(), Integer.valueOf(1109));
+            assertEquals(e.getErrorResponse().getMessage(), "unauthorized product");
         }
     }
 


### PR DESCRIPTION
Fixes #36. Seems like #33 had been abandoned so just wanted to get this fixed. [The API endpoint](https://plaid.com/docs/#retrieve-info-data) requires a GET request with an access token, rather than a POST with credentials.

