### PR TITLE
Custom deserializer for institution so search by id endpoint can be used

### DIFF
--- a/src/main/java/com/plaid/client/DefaultPlaidPublicClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidPublicClient.java
@@ -1,8 +1,11 @@
 package com.plaid.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.plaid.client.exception.PlaidClientsideException;
 import com.plaid.client.http.HttpDelegate;
 import com.plaid.client.http.HttpResponseWrapper;
+import com.plaid.client.http.InstitutionDeserializer;
 import com.plaid.client.http.PlaidHttpRequest;
 import com.plaid.client.request.MappingOptions;
 import com.plaid.client.response.CategoriesResponse;
@@ -24,9 +27,19 @@ public class DefaultPlaidPublicClient implements PlaidPublicClient {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
+    //note that the institution id is the institution_type on account objects
     @Override
-    public Object getInstitution(String institutionId) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    public Institution getInstitution(String institutionId) {
+        PlaidHttpRequest request = new PlaidHttpRequest("/institutions/search");
+        request.addParameter("id", institutionId);
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Institution.class, new InstitutionDeserializer());
+        mapper.registerModule(module);
+        this.httpDelegate.setObjectMapper(mapper);
+        HttpResponseWrapper<Institution> response = httpDelegate.doGet(request, Institution.class);
+        this.httpDelegate.setObjectMapper(new ObjectMapper());
+        return response.getResponseBody();
     }
 
     @Override

--- a/src/main/java/com/plaid/client/PlaidPublicClient.java
+++ b/src/main/java/com/plaid/client/PlaidPublicClient.java
@@ -3,14 +3,15 @@ package com.plaid.client;
 import com.plaid.client.http.HttpDelegate;
 import com.plaid.client.request.MappingOptions;
 import com.plaid.client.response.CategoriesResponse;
+import com.plaid.client.response.Institution;
 import com.plaid.client.response.InstitutionsResponse;
 import com.plaid.client.response.LongTailInstitutionsResponse;
 
 public interface PlaidPublicClient {
 
     Object getEntity(String entityId);
-    
-    Object getInstitution(String institutionId);
+
+    Institution getInstitution(String institutionId);
     
     InstitutionsResponse getAllInstitutions();
 

--- a/src/main/java/com/plaid/client/http/HttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/HttpDelegate.java
@@ -1,7 +1,8 @@
 package com.plaid.client.http;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-public interface HttpDelegate {    
+public interface HttpDelegate {
 
     <T> HttpResponseWrapper<T> doPost(PlaidHttpRequest request, Class<T> clazz);
     
@@ -10,5 +11,6 @@ public interface HttpDelegate {
     <T> HttpResponseWrapper<T> doPatch(PlaidHttpRequest request, Class<T> clazz);
 
     <T> HttpResponseWrapper<T> doDelete(PlaidHttpRequest request, Class<T> clazz);
-    
+
+    void setObjectMapper(ObjectMapper mapper);
 }

--- a/src/main/java/com/plaid/client/http/InstitutionDeserializer.java
+++ b/src/main/java/com/plaid/client/http/InstitutionDeserializer.java
@@ -1,0 +1,41 @@
+package com.plaid.client.http;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.plaid.client.response.Institution;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+// this class is necessary to properly deserialize Institutions returned by the institution/search endpoint
+public class InstitutionDeserializer extends JsonDeserializer<Institution> {
+    @Override
+    public Institution deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = jp.getCodec().readTree(jp);
+        String id = node.get("id").asText();
+        String name = node.get("name").asText();
+        Boolean hasMfa = (node.get("has_mfa") != null) ? node.get("has_mfa").asBoolean() : null;
+        Map<String, Boolean> productsMap = mapper.convertValue(node.get("products"), Map.class);
+        List<String> mfa = mapper.convertValue(node.get("mfa"), List.class);
+        Institution.CredentialNames credentialNames = mapper.convertValue(node.get("credentials"), Institution.CredentialNames.class);
+        String type = node.get("type").asText();
+        List products = new ArrayList(productsMap.keySet());
+        return new Institution.InstitutionBuilder().setCredentialNames(credentialNames)
+                .setHasMfa(hasMfa)
+                .setId(id)
+                .setMfaTypes(mfa)
+                .setName(name)
+                .setProducts(products)
+                .setType(type)
+                .createInstitution();
+    }
+
+}
+

--- a/src/main/java/com/plaid/client/response/Institution.java
+++ b/src/main/java/com/plaid/client/response/Institution.java
@@ -16,6 +16,27 @@ public class Institution {
     private List<String> products;
     private String type;
 
+    public Institution() {
+    }
+
+    ;
+
+    private Institution(final CredentialNames credentialNames,
+                        final Boolean hasMfa,
+                        final String id,
+                        final List<String> mfaTypes,
+                        final String name,
+                        final List<String> products,
+                        final String type) {
+        this.credentialNames = credentialNames;
+        this.hasMfa = hasMfa;
+        this.id = id;
+        this.mfaTypes = mfaTypes;
+        this.name = name;
+        this.products = products;
+        this.type = type;
+    }
+
     @JsonProperty("credentials")
     public CredentialNames getCredentialNames() {
         return credentialNames;
@@ -25,13 +46,13 @@ public class Institution {
         this.credentialNames = credentialNames;
     }
 
+    public boolean isHasMfa() {
+        return hasMfa;
+    }
+
     @JsonProperty("has_mfa")
     public void setHasMfa(boolean hasMfa) {
         this.hasMfa = hasMfa;
-    }
-
-    public boolean isHasMfa() {
-        return hasMfa;
     }
 
     @JsonProperty("mfa")
@@ -104,6 +125,55 @@ public class Institution {
 
         public void setPin(String pin) {
             this.pin = pin;
+        }
+    }
+
+    public static class InstitutionBuilder {
+        private Institution.CredentialNames credentialNames;
+        private Boolean hasMfa;
+        private String id;
+        private List<String> mfaTypes;
+        private String name;
+        private List<String> products;
+        private String type;
+
+        public InstitutionBuilder setCredentialNames(final Institution.CredentialNames credentialNames) {
+            this.credentialNames = credentialNames;
+            return this;
+        }
+
+        public InstitutionBuilder setHasMfa(final Boolean hasMfa) {
+            this.hasMfa = hasMfa;
+            return this;
+        }
+
+        public InstitutionBuilder setId(final String id) {
+            this.id = id;
+            return this;
+        }
+
+        public InstitutionBuilder setMfaTypes(final List<String> mfaTypes) {
+            this.mfaTypes = mfaTypes;
+            return this;
+        }
+
+        public InstitutionBuilder setName(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        public InstitutionBuilder setProducts(final List<String> products) {
+            this.products = products;
+            return this;
+        }
+
+        public InstitutionBuilder setType(final String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Institution createInstitution() {
+            return new Institution(credentialNames, hasMfa, id, mfaTypes, name, products, type);
         }
     }
 

--- a/src/test/java/com/plaid/client/PlaidPublicClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidPublicClientTest.java
@@ -1,24 +1,23 @@
 package com.plaid.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import com.plaid.client.exception.PlaidClientsideException;
+import com.plaid.client.http.ApacheHttpClientHttpDelegate;
+import com.plaid.client.http.HttpDelegate;
+import com.plaid.client.response.CategoriesResponse;
+import com.plaid.client.response.Institution;
+import com.plaid.client.response.InstitutionsResponse;
 import com.plaid.client.response.LongTailInstitutionsResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.plaid.client.http.ApacheHttpClientHttpDelegate;
-import com.plaid.client.http.HttpDelegate;
-import com.plaid.client.response.CategoriesResponse;
-import com.plaid.client.response.Institution;
-import com.plaid.client.response.InstitutionsResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class PlaidPublicClientTest {
     
@@ -74,5 +73,11 @@ public class PlaidPublicClientTest {
     public void testGetAllLongTailInstitutions() throws Exception {
         LongTailInstitutionsResponse response = plaidPublicClientWithCredentials.getAllLongTailInstitutions(0, 10);
         assertEquals(10, response.getResults().length);
+    }
+
+    @Test
+    public void testGetSearchableInstitution() throws Exception {
+        Institution institutionResponse = plaidPublicClientWithoutCredentials.getInstitution("suntrust");
+        assertEquals("SunTrust", institutionResponse.getName());
     }
 }


### PR DESCRIPTION
It looks like the reason no one has implemented this yet is because the institutions/search endpoint returns institutions differently than https://tartan.plaid.com/institutions, specifically the product list is returned as a hashmap of <string,boolean> instead of a list<string>.

I've written a pretty dumb objectmapper which gets switched out when a request to this endpoint is made which can handle the deserialization correctly. 

If there is a better way to do this I am all ears, apologies for my editor moving some code around.

-Sam Van Ryssegem