### PR TITLE
Enabling ability to support tls 1.2 for jdk 1.7 users

### DIFF
--- a/src/main/java/com/plaid/client/PlaidClients.java
+++ b/src/main/java/com/plaid/client/PlaidClients.java
@@ -95,7 +95,7 @@ public class PlaidClients {
 
         ApacheHttpClientHttpDelegate httpDelegate;
         if (test) {
-            httpDelegate = new ApacheHttpClientHttpDelegate(uri, HttpClientBuilder.create().disableContentCompression().build());
+            httpDelegate = new ApacheHttpClientHttpDelegate(uri, HttpClientBuilder.create().disableContentCompression().useSystemProperties().build());
         }
         else {
             httpDelegate = ApacheHttpClientHttpDelegate.createDefault(uri);

--- a/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
@@ -107,6 +107,7 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
     @Override
     public <T> HttpResponseWrapper<T> doGet(PlaidHttpRequest request, Class<T> clazz) {
         try {
+
             List<NameValuePair> parameters = mapToNvps(request.getParameters());
 
             URI uri = new URIBuilder(baseUri)
@@ -134,6 +135,7 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
     @Override
     public <T> HttpResponseWrapper<T> doDelete(PlaidHttpRequest request, Class<T> clazz) {
         try {
+
             List<NameValuePair> parameters = mapToNvps(request.getParameters());
 
             URI uri = new URIBuilder(baseUri)

--- a/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
@@ -134,7 +134,6 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
     @Override
     public <T> HttpResponseWrapper<T> doDelete(PlaidHttpRequest request, Class<T> clazz) {
         try {
-
             List<NameValuePair> parameters = mapToNvps(request.getParameters());
 
             URI uri = new URIBuilder(baseUri)

--- a/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,9 +24,12 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -37,6 +42,8 @@ import com.plaid.client.exception.PlaidServersideUnknownResponseException;
 import com.plaid.client.response.ErrorResponse;
 import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.UnknownResponse;
+
+import javax.net.ssl.SSLContext;
 
 public class ApacheHttpClientHttpDelegate implements HttpDelegate {
 
@@ -118,7 +125,13 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
 
             addUserAgent(get);
 
-            CloseableHttpResponse response = httpClient.execute(get);
+            SSLConnectionSocketFactory f = SSLConnectionSocketFactory.getSystemSocketFactory();
+
+            CloseableHttpClient _httpClient = HttpClients.custom()
+                    .setSSLSocketFactory(f)
+                    .build();
+
+            CloseableHttpResponse response = _httpClient.execute(get);
 
             return handleResponse(get, response, clazz);
 

--- a/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
@@ -38,6 +38,7 @@ import com.plaid.client.exception.PlaidServersideUnknownResponseException;
 import com.plaid.client.response.ErrorResponse;
 import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.UnknownResponse;
+import sun.net.www.http.HttpClient;
 
 import javax.net.ssl.SSLContext;
 
@@ -66,7 +67,8 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
     }
 
     public static ApacheHttpClientHttpDelegate createDefault(String baseUri) {
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = System.getProperty("https.protocols") == null ?
+                HttpClients.createDefault() : HttpClients.createSystem();
         return new ApacheHttpClientHttpDelegate(baseUri, httpClient);
     }
 

--- a/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
+++ b/src/main/java/com/plaid/client/http/ApacheHttpClientHttpDelegate.java
@@ -22,7 +22,6 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
@@ -38,9 +37,6 @@ import com.plaid.client.exception.PlaidServersideUnknownResponseException;
 import com.plaid.client.response.ErrorResponse;
 import com.plaid.client.response.MfaResponse;
 import com.plaid.client.response.UnknownResponse;
-import sun.net.www.http.HttpClient;
-
-import javax.net.ssl.SSLContext;
 
 public class ApacheHttpClientHttpDelegate implements HttpDelegate {
 
@@ -52,14 +48,7 @@ public class ApacheHttpClientHttpDelegate implements HttpDelegate {
 
     public ApacheHttpClientHttpDelegate(String baseUri, CloseableHttpClient httpClient) {
         this.baseUri = baseUri;
-
-        if(System.getProperty("https.protocols") != null) {
-            SSLConnectionSocketFactory f = SSLConnectionSocketFactory.getSystemSocketFactory();
-            this.httpClient = HttpClients.custom().setSSLSocketFactory(f).build();
-        } else {
-            this.httpClient = httpClient;
-        }
-
+        this.httpClient = httpClient;
         this.jsonMapper = new ObjectMapper();
         if (LIBRARY_VERSION == null) {
         	LIBRARY_VERSION = "development version";

--- a/src/test/java/com/plaid/client/PlaidPublicClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidPublicClientTest.java
@@ -32,7 +32,7 @@ public class PlaidPublicClientTest {
 
     @Before
     public  void setup() {
-        httpClient = HttpClients.custom().disableContentCompression().build();
+        httpClient = HttpClients.custom().disableContentCompression().useSystemProperties().build();
         //httpDelegate = new ApacheHttpClientHttpDelegate("http://localhost:8089", httpClient);
         HttpDelegate httpDelegate = new ApacheHttpClientHttpDelegate("https://tartan.plaid.com", httpClient);
         plaidPublicClientWithoutCredentials = new DefaultPlaidPublicClient.Builder()

--- a/src/test/java/com/plaid/client/PlaidUserClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidUserClientTest.java
@@ -38,7 +38,7 @@ public class PlaidUserClientTest {
     @Before
     public  void setup() {
         //httpClient = HttpClients.createDefault();
-        httpClient = HttpClients.custom().disableContentCompression().build();
+        httpClient = HttpClients.custom().disableContentCompression().useSystemProperties().build();
         //httpDelegate = new ApacheHttpClientHttpDelegate("http://localhost:8089", httpClient);
         httpDelegate = new ApacheHttpClientHttpDelegate("https://tartan.plaid.com", httpClient);
         plaidUserClient = new DefaultPlaidUserClient.Builder()


### PR DESCRIPTION
fix for using tls 1.2 for jdk 1.7 users to use system defined protocol. allows for explicit definition of 
-Dhttps.protocols=TLSv1.1,TLSv1.2