### PR TITLE
Adds accountId parameter to exchangeToken

### DIFF
--- a/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
+++ b/src/main/java/com/plaid/client/DefaultPlaidUserClient.java
@@ -58,6 +58,15 @@ public class DefaultPlaidUserClient implements PlaidUserClient {
     }
 
     @Override
+    public PlaidUserResponse exchangeToken(String publicToken, String accountId) {
+        Map<String, Object> requestParams = new HashMap<String, Object>();
+        requestParams.put("public_token", publicToken);
+        requestParams.put("account_id", accountId);
+
+        return handlePost("/exchange_token", requestParams, PlaidUserResponse.class);
+    }
+
+    @Override
     public TransactionsResponse addUser(Credentials credentials, String type, String email, ConnectOptions connectOptions) throws PlaidMfaException {
 
         Map<String, Object> requestParams = new HashMap<String, Object>();

--- a/src/main/java/com/plaid/client/PlaidUserClient.java
+++ b/src/main/java/com/plaid/client/PlaidUserClient.java
@@ -23,6 +23,8 @@ public interface PlaidUserClient {
 
     PlaidUserResponse exchangeToken(String publicToken);
 
+    PlaidUserResponse exchangeToken(String publicToken, String accountId);
+
     TransactionsResponse addUser(Credentials credentials, String type, String email, ConnectOptions connectOptions) throws PlaidMfaException;
 
     TransactionsResponse mfaConnectStep(String mfa, String type) throws PlaidMfaException;

--- a/src/test/java/com/plaid/client/PlaidUserClientTest.java
+++ b/src/test/java/com/plaid/client/PlaidUserClientTest.java
@@ -191,5 +191,25 @@ public class PlaidUserClientTest {
         }
     }
 
+    @Test
+    public void testExchangeTokenWithAccountIdSuccess() {
+        PlaidUserResponse response = plaidUserClient.exchangeToken("test,chase,connected", "QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK");
+
+        assertEquals("test_chase", response.getAccessToken());
+    }
+
+    //Result is "1109 unauthorized product" in Sandbox
+    @Ignore
+    @Test
+    public void testExchangeTokenWithAccountIdFailure() {
+        try {
+            plaidUserClient.exchangeToken("invalid_public_token", "QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK");
+        } catch (PlaidServersideException e) {
+            assertEquals(HttpStatus.SC_UNAUTHORIZED, e.getHttpStatusCode());
+            assertEquals(1106, e.getErrorResponse().getCode().intValue());
+            assertEquals("bad public_token", e.getErrorResponse().getMessage());
+        }
+    }
+
 
 }


### PR DESCRIPTION
Fixes #34.

This PR lets users use the `account_id` parameter in the request to `/exchange_token`. This is necessary to exchange a Plaid public token for a Stripe bank account token.
