### PR TITLE
Fix serializing subclassed TransactionGetRequest.Options

### DIFF
--- a/src/main/java/com/plaid/client/PlaidClient.java
+++ b/src/main/java/com/plaid/client/PlaidClient.java
@@ -182,7 +182,7 @@ public final class PlaidClient {
         .registerTypeAdapterFactory(new RequiredFieldTypeAdapterFactory())
         .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
         .registerTypeAdapterFactory(new ImmutableListTypeAdapterFactory())
-        .registerTypeAdapter(TransactionsGetRequest.Options.class, new BaseOptionsSerializer())
+        .registerTypeAdapter(TransactionsGetRequest.BaseOptions.class, new BaseOptionsSerializer())
         .create();
     }
 

--- a/src/test/java/com/plaid/client/internal/gson/BaseOptionsSerializerTest.java
+++ b/src/test/java/com/plaid/client/internal/gson/BaseOptionsSerializerTest.java
@@ -21,6 +21,11 @@ public class BaseOptionsSerializerTest {
     private TransactionsGetRequest.Options options = new TransactionsGetRequest.Options();
   }
 
+  public static class OptionalContainer {
+    private Optional<TransactionsGetRequest.BaseOptions> options = Optional.of(new ChildOptions());
+  }
+
+
   @Test public void testSerializesChildren() {
     Gson gson = new GsonBuilder()
       .registerTypeAdapter(TransactionsGetRequest.BaseOptions.class, new BaseOptionsSerializer())
@@ -31,6 +36,19 @@ public class BaseOptionsSerializerTest {
     String result = gson.toJson(child);
     assertEquals("{\"options\":{\"anotherIntValue\":2}}", result);
   }
+
+  @Test public void testSerializesChildrenWithOptional() {
+    Gson gson = new GsonBuilder()
+            .registerTypeAdapter(TransactionsGetRequest.BaseOptions.class, new BaseOptionsSerializer())
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .create();
+
+    OptionalContainer optional = new OptionalContainer();
+
+    String result = gson.toJson(optional);
+    assertEquals("{\"options\":{\"anotherIntValue\":2}}", result);
+  }
+
 
   @Test public void testSerializesBase() {
     Gson gson = new GsonBuilder()


### PR DESCRIPTION
When adding a custom option to `TransactionGetRequest.Options` (by extending it) I noticed that it was not getting serialized - Even though support for this was added in https://github.com/plaid/plaid-java/pull/110.