### PR TITLE
Adding support for Item status info

### DIFF
--- a/src/main/java/com/plaid/client/response/ItemGetResponse.java
+++ b/src/main/java/com/plaid/client/response/ItemGetResponse.java
@@ -2,8 +2,13 @@ package com.plaid.client.response;
 
 public final class ItemGetResponse extends BaseResponse {
   private ItemStatus item;
+  private ItemStatusStatus status;
 
   public ItemStatus getItem() {
     return item;
+  }
+
+  public ItemStatusStatus getStatus() {
+    return status;
   }
 }

--- a/src/main/java/com/plaid/client/response/ItemStatusStatus.java
+++ b/src/main/java/com/plaid/client/response/ItemStatusStatus.java
@@ -1,0 +1,42 @@
+package com.plaid.client.response;
+
+import java.util.Date;
+
+public final class ItemStatusStatus {
+  private ItemStatusTransactions transactions;
+  private ItemStatusWebhook lastWebhook;
+
+  public ItemStatusTransactions getTransactions() {
+    return transactions;
+  }
+
+  public ItemStatusWebhook getLastWebhook() {
+    return lastWebhook;
+  }
+
+  public static final class ItemStatusTransactions {
+    private Date lastSuccessfulUpdate;
+    private Date lastFailedUpdate;
+
+    public Date getLastSuccessfulUpdate() {
+      return lastSuccessfulUpdate;
+    }
+
+    public Date getLastFailedUpdate() {
+      return lastFailedUpdate;
+    }
+  }
+
+  public static final class ItemStatusWebhook {
+    private Date sentAt;
+    private String codeSent;
+
+    public Date getSentAt() {
+      return sentAt;
+    }
+
+    public String getCodeSent() {
+      return codeSent;
+    }
+  }
+}


### PR DESCRIPTION
Adding support for Item status from `item/get`. Note: the docs (https://plaid.com/docs/#retrieve-item) are actually wrong about the location of the of the "status" field in the returned object. It's one level higher than the docs claim/

Separately, I feel bad about the name ItemStatusStatus, but it's a little weird with ItemStatus already existing and being part of the existing API. Open to suggestions.

Tested by making a call to the Plaid Sandbox and fetching an item.