### PR TITLE
Fix compilation and tests broken by assets changes

### DIFF
--- a/src/main/java/com/plaid/client/response/IdentityGetResponse.java
+++ b/src/main/java/com/plaid/client/response/IdentityGetResponse.java
@@ -1,6 +1,7 @@
 package com.plaid.client.response;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class IdentityGetResponse extends BaseResponse {
   private ItemStatus item;

--- a/src/main/java/com/plaid/client/response/IdentityGetResponse.java
+++ b/src/main/java/com/plaid/client/response/IdentityGetResponse.java
@@ -103,6 +103,27 @@ public final class IdentityGetResponse extends BaseResponse {
     public String getCountry() {
       return country;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      AddressData addressData = (AddressData) obj;
+      return Objects.equals(street, addressData.street) &&
+          Objects.equals(city, addressData.city) &&
+          Objects.equals(region, addressData.region) &&
+          Objects.equals(postalCode, addressData.postalCode) &&
+          Objects.equals(country, addressData.country);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(street, city, region, postalCode, country);
+    }
   }
 
   public static final class Email {


### PR DESCRIPTION
I had not run `mvn verify` locally when merging https://github.com/plaid/plaid-java/pull/164 and did not realize I had to run tests locally (CI does not run the tests so I have created https://jira.plaid.com/browse/CLIB-140). @evndean ran this command locally and messaged me about compilation failure.

I'm seeing some test failures locally right now which I'm fixing (so this PR is WIP):
```
Results:

Failed tests:
  AssetReportRefreshTest.testAssetReportRefreshSuccessNoOverrideOptions:82 expected:<[com.plaid.client.response.AssetReportGetResponse$Item@e6228129]> but was:<[com.plaid.client.response.AssetReportGetResponse$Item@7dc8ee1b]>
  AssetReportRefreshTest.testAssetReportRefreshSuccessWithOverride:126 expected:<[com.plaid.client.response.AssetReportGetResponse$Item@4da59f3e]> but was:<[com.plaid.client.response.AssetReportGetResponse$Item@f1229ee1]>
Tests in error:
  InstitutionsGetByIdTest.testSuccessWithIncludeStatusTrue:88 » JsonSyntax java....

Tests run: 76, Failures: 2, Errors: 1, Skipped: 3
```