### PR TITLE
Add support for Ocrolus processor tokens

### DIFF
--- a/src/main/java/com/plaid/client/PlaidApiService.java
+++ b/src/main/java/com/plaid/client/PlaidApiService.java
@@ -24,6 +24,7 @@ import com.plaid.client.request.InstitutionsSearchRequest;
 import com.plaid.client.request.ItemAccessTokenInvalidateRequest;
 import com.plaid.client.request.ItemApexProcessorTokenCreateRequest;
 import com.plaid.client.request.ItemDwollaProcessorTokenCreateRequest;
+import com.plaid.client.request.ItemOcrolusProcessorTokenCreateRequest;
 import com.plaid.client.request.ItemGetRequest;
 import com.plaid.client.request.ItemPublicTokenCreateRequest;
 import com.plaid.client.request.ItemPublicTokenExchangeRequest;
@@ -55,6 +56,7 @@ import com.plaid.client.response.InstitutionsSearchResponse;
 import com.plaid.client.response.ItemAccessTokenInvalidateResponse;
 import com.plaid.client.response.ItemApexProcessorTokenCreateResponse;
 import com.plaid.client.response.ItemDwollaProcessorTokenCreateResponse;
+import com.plaid.client.response.ItemOcrolusProcessorTokenCreateResponse;
 import com.plaid.client.response.ItemGetResponse;
 import com.plaid.client.response.ItemPublicTokenCreateResponse;
 import com.plaid.client.response.ItemPublicTokenExchangeResponse;
@@ -93,6 +95,9 @@ public interface PlaidApiService {
 
   @POST("/processor/dwolla/processor_token/create")
   Call<ItemDwollaProcessorTokenCreateResponse> itemDwollaProcessorTokenCreate(@Body ItemDwollaProcessorTokenCreateRequest request);
+
+  @POST("/processor/ocrolus/processor_token/create")
+  Call<ItemOcrolusProcessorTokenCreateResponse> itemOcrolusProcessorTokenCreate(@Body ItemOcrolusProcessorTokenCreateRequest request);
 
   @POST("/item/access_token/invalidate")
   Call<ItemAccessTokenInvalidateResponse> itemAccessTokenInvalidate(@Body ItemAccessTokenInvalidateRequest request);

--- a/src/main/java/com/plaid/client/request/ItemOcrolusProcessorTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemOcrolusProcessorTokenCreateRequest.java
@@ -1,0 +1,15 @@
+package com.plaid.client.request;
+
+import com.plaid.client.request.common.BaseAccessTokenRequest;
+
+/**
+ * Request for  /processor/ocrolus/processor_token/create endpoint.
+ */
+public final class ItemOcrolusProcessorTokenCreateRequest extends BaseAccessTokenRequest {
+  private String accountId;
+
+  public ItemOcrolusProcessorTokenCreateRequest(String accessToken, String accountId) {
+    super(accessToken);
+    this.accountId = accountId;
+  }
+}

--- a/src/main/java/com/plaid/client/response/ItemOcrolusProcessorTokenCreateResponse.java
+++ b/src/main/java/com/plaid/client/response/ItemOcrolusProcessorTokenCreateResponse.java
@@ -1,0 +1,12 @@
+package com.plaid.client.response;
+
+/**
+ * Response from /processor/ocrolus/processor_token/create endpoint.
+ */
+public final class ItemOcrolusProcessorTokenCreateResponse extends BaseResponse {
+  private String processorToken;
+
+  public String getProcessorToken() {
+    return processorToken;
+  }
+}

--- a/src/test/java/com/plaid/client/integration/ItemOcrolusProcessorTokenCreateTest.java
+++ b/src/test/java/com/plaid/client/integration/ItemOcrolusProcessorTokenCreateTest.java
@@ -1,0 +1,41 @@
+package com.plaid.client.integration;
+
+import com.plaid.client.request.ItemOcrolusProcessorTokenCreateRequest;
+import com.plaid.client.request.common.Product;
+import com.plaid.client.response.ErrorResponse;
+import com.plaid.client.response.ItemOcrolusProcessorTokenCreateResponse;
+import org.junit.Test;
+import retrofit2.Response;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ItemOcrolusProcessorTokenCreateTest extends AbstractItemIntegrationTest {
+  @Override
+  protected List<Product> setupItemProducts() {
+    return Arrays.asList(Product.AUTH);
+  }
+
+  @Override
+  protected String setupItemInstitutionId() {
+    return TARTAN_BANK_INSTITUTION_ID;
+  }
+
+  @Test
+  public void testError() throws Exception {
+    Response<ItemOcrolusProcessorTokenCreateResponse> response =
+      client().service().itemOcrolusProcessorTokenCreate(new ItemOcrolusProcessorTokenCreateRequest(getItemPublicTokenExchangeResponse().getAccessToken(), "FooBarAccountId")).execute();
+    // Just assert that some error was returned - due to the nature of the
+    // integration and required configuration at the API key level, we don't
+    // know the exact error code to expect.
+    assertFalse(response.isSuccessful());
+    assertNotNull(response.errorBody());
+
+    ErrorResponse errorResponse = client().parseError(response);
+    assertNotNull(errorResponse);
+    assertNotNull(errorResponse.getRequestId());
+  }
+}


### PR DESCRIPTION
## Changes

* Adds support for creating Ocrolus processor tokens.

Note that I am unable to compile the code and run the tests, due to the bug that #167 is resolving. But since this is based on the working Dwolla code, this should work fine once that bug is resolved. Still, we should probably hold off on merging this until #167 gets merged.