### PR TITLE
Fix compilation and tests broken by assets changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
+      # command: /sbin/init
     steps:
     - checkout
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-machine:
-  java:
-    version: oraclejdk8
-test:
-  override:
-    - mvn verify

--- a/src/main/java/com/plaid/client/response/IdentityGetResponse.java
+++ b/src/main/java/com/plaid/client/response/IdentityGetResponse.java
@@ -104,6 +104,27 @@ public final class IdentityGetResponse extends BaseResponse {
     public String getCountry() {
       return country;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      AddressData addressData = (AddressData) obj;
+      return Objects.equals(street, addressData.street) &&
+          Objects.equals(city, addressData.city) &&
+          Objects.equals(region, addressData.region) &&
+          Objects.equals(postalCode, addressData.postalCode) &&
+          Objects.equals(country, addressData.country);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(street, city, region, postalCode, country);
+    }
   }
 
   public static final class Email {

--- a/src/main/java/com/plaid/client/response/IdentityGetResponse.java
+++ b/src/main/java/com/plaid/client/response/IdentityGetResponse.java
@@ -2,6 +2,7 @@ package com.plaid.client.response;
 
 import java.util.Objects;
 import java.util.List;
+import java.util.Objects;
 
 public final class IdentityGetResponse extends BaseResponse {
   private ItemStatus item;


### PR DESCRIPTION
I had not run `mvn verify` locally when merging https://github.com/plaid/plaid-java/pull/164 and did not realize I had to run tests locally (CI does not run the tests so I have created https://jira.plaid.com/browse/CLIB-140).

Creating PR from my fork of plaid-java repo was triggering CI tests to be run on my skansal-plaid CircleCI account. So i'm creating PR by directly branching off plaid-java repo (instead of using my repo fork). This PR replaces https://github.com/plaid/plaid-java/pull/165.