### PR TITLE
Add options.accountFilter to /institutions/search

### DIFF
--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -51,8 +51,17 @@ public final class InstitutionsSearchRequest extends BasePublicRequest {
     return this;
   }
 
+  public InstitutionsSearchRequest withAccountFilter(Map<String, List<String>> accountFilter) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.accountFilter = accountFilter;
+    return this;
+  }
+
   private static class Options {
     private boolean includeOptionalMetadata;
     private List<String> countryCodes;
+    private Map<String, List<String>> accountFilter;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -7,6 +7,7 @@ import com.plaid.client.request.common.Product;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.plaid.client.internal.Util.notEmpty;
 import static com.plaid.client.internal.Util.notNull;

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -64,7 +64,11 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
       "loan", Arrays.asList("student")
     );
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest("wells").withCountryCodes(Arrays.asList("US")).withAccountFilter(accountFilter)).execute();
+        client().service().institutionsSearch(new InstitutionsSearchRequest("wells")
+        .withCountryCodes(Arrays.asList("US"))
+        .withAccountFilter(accountFilter))
+        .withProducts(Product.LIABILITIES)
+        .execute();
 
     assertSuccessResponse(response);
 

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -59,6 +59,19 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   }
 
   @Test
+  public void testSuccessWithAccountFilter() throws Exception {
+    Map<String, List<String>> accountFilter = Map.of(
+      "loan", Arrays.asList("student")
+    );
+    Response<InstitutionsSearchResponse> response =
+        client().service().institutionsSearch(new InstitutionsSearchRequest("wells").withCountryCodes(Arrays.asList("US")).withAccountFilter(accountFilter)).execute();
+
+    assertSuccessResponse(response);
+
+    assertTrue(0, response.body().getInstitutions().size() > 0);
+  }
+
+  @Test
   public void testNoResults() throws Exception {
     Response<InstitutionsSearchResponse> response =
       client().service().institutionsSearch(new InstitutionsSearchRequest("zebra")).execute();

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import retrofit2.Response;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,9 +64,9 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithAccountFilter() throws Exception {
-    Map<String, List<String>> accountFilter = Map.of(
-      "loan", Arrays.asList("student")
-    );
+    Map<String, List<String>> accountFilter = new HashMap<>();
+    accountFilter.put("loan", Arrays.asList("student"));
+
     Response<InstitutionsSearchResponse> response =
         client().service().institutionsSearch(new InstitutionsSearchRequest("wells")
           .withCountryCodes(Arrays.asList("US"))
@@ -75,7 +76,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
 
     assertSuccessResponse(response);
 
-    assertTrue(0, response.body().getInstitutions().size() > 0);
+    assertTrue(response.body().getInstitutions().size() > 0);
   }
 
   @Test

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -7,10 +7,13 @@ import org.junit.Test;
 import retrofit2.Response;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -65,10 +65,10 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
     );
     Response<InstitutionsSearchResponse> response =
         client().service().institutionsSearch(new InstitutionsSearchRequest("wells")
-        .withCountryCodes(Arrays.asList("US"))
-        .withAccountFilter(accountFilter))
-        .withProducts(Product.LIABILITIES)
-        .execute();
+          .withCountryCodes(Arrays.asList("US"))
+          .withAccountFilter(accountFilter)
+          .withProducts(Product.LIABILITIES)
+        ).execute();
 
     assertSuccessResponse(response);
 


### PR DESCRIPTION
Adding a new field, `accountFilter` to `/institutions/search` request options.