### PR TITLE
Fix institution_get_by_id test

### DIFF
--- a/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
@@ -1,13 +1,7 @@
 package com.plaid.client.request;
 
-import com.plaid.client.internal.gson.RequiredField;
 import com.plaid.client.request.common.BasePublicRequest;
-import com.plaid.client.request.common.Product;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
-import static com.plaid.client.internal.Util.notEmpty;
 import static com.plaid.client.internal.Util.notNull;
 
 /**

--- a/src/main/java/com/plaid/client/response/Institution.java
+++ b/src/main/java/com/plaid/client/response/Institution.java
@@ -2,7 +2,7 @@ package com.plaid.client.response;
 
 import com.plaid.client.request.common.Product;
 
-import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 
 public final class Institution {
@@ -44,14 +44,14 @@ public final class Institution {
 
   public static final class ItemLogins {
     private String status;
-    private Time lastStatusChange;
+    private Timestamp lastStatusChange;
     private InstitutionStatusBreakdown breakdown;
 
     public String getStatus() {
       return status;
     }
 
-    public Time getLastStatusChange() {
+    public Timestamp getLastStatusChange() {
       return lastStatusChange;
     }
 

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
@@ -8,7 +8,6 @@ import com.plaid.client.response.InstitutionsGetByIdResponse;
 import org.junit.Test;
 import retrofit2.Response;
 
-import java.util.List;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
Fixing tests related to `InstitutionsGetById`:

```
  testSuccessWithIncludeStatusTrue(com.plaid.client.integration.InstitutionsGetByIdTest)  Time elapsed: 1.763 sec  <<< ERROR!
    com.google.gson.JsonSyntaxException: java.text.ParseException: Unparseable date: "2019-10-29T17:29:58Z"
        at com.plaid.client.integration.InstitutionsGetByIdTest.testSuccessWithIncludeStatusTrue(InstitutionsGetByIdTest.java:88)
    Caused by: java.text.ParseException: Unparseable date: "2019-10-29T17:29:58Z"
        at com.plaid.client.integration.InstitutionsGetByIdTest.testSuccessWithIncludeStatusTrue(InstitutionsGetByIdTest.java:88)
```

Converting `Time` to `Timestamp` resolved the issue locally for me