### PR TITLE
Revert "Add VerificationStatus to Account object"

### DIFF
--- a/src/main/java/com/plaid/client/response/Account.java
+++ b/src/main/java/com/plaid/client/response/Account.java
@@ -8,7 +8,6 @@ public class Account {
   private String name;
   private String mask;
   private String officialName;
-  private String verificationStatus;
 
   public String getAccountId() {
     return accountId;
@@ -36,10 +35,6 @@ public class Account {
 
   public String getOfficialName() {
     return officialName;
-  }
-
-  public String getVerificationStatus() {
-    return verificationStatus;
   }
 
   public static final class Balances {


### PR DESCRIPTION
Reverts plaid/plaid-java#178

This PR broke the build as it turns out the `verification_status` is not being sent in the Account object within the Retrieve Accounts API call. 

The docs for this API call will need to be adjusted potentially, https://plaid.com/docs/#retrieve-accounts-request.

Example response when I call the endpoint:
```
{
  "accounts": [
    {
      "account_id": "GZbZJmdJgrsrNzK7WXadC6LrxnxwxXt1ldvd3",
      "balances": {
        "available": 100,
        "current": 110,
        "iso_currency_code": "USD",
        "limit": null,
        "unofficial_currency_code": null
      },
      "mask": "0000",
      "name": "Plaid Checking",
      "official_name": "Plaid Gold Standard 0% Interest Checking",
      "subtype": "checking",
      "type": "depository"
    }, 
    ...
  ],
  "item": {
   ...
  },
  "request_id": "kdzwQG55LArPwGV"
}
```