### PR TITLE
Add OAuth support to /institutions endpoints

### DIFF
--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -50,11 +50,11 @@ public final class InstitutionsGetRequest extends BaseClientRequest {
     return this;
   }
 
-  public InstitutionsGetRequest withOAuth() {
+  public InstitutionsGetRequest withOAuth(boolean oauth) {
     if (this.options == null) {
       this.options = new Options();
     }
-    this.options.oauth = true;
+    this.options.oauth = oauth;
     return this;
   }
 
@@ -62,6 +62,6 @@ public final class InstitutionsGetRequest extends BaseClientRequest {
     private List<Product> products;
     private boolean includeOptionalMetadata;
     private List<String> countryCodes;
-    private boolean oauth;
+    private Boolean oauth;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -50,9 +50,18 @@ public final class InstitutionsGetRequest extends BaseClientRequest {
     return this;
   }
 
+  public InstitutionsGetRequest withOAuth() {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.oauth = true;
+    return this;
+  }
+
   private static class Options {
     private List<Product> products;
     private boolean includeOptionalMetadata;
     private List<String> countryCodes;
+    private boolean oauth;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -60,11 +60,11 @@ public final class InstitutionsSearchRequest extends BasePublicRequest {
     return this;
   }
 
-  public InstitutionsSearchRequest withOAuth() {
+  public InstitutionsSearchRequest withOAuth(oauth boolean) {
     if (this.options == null) {
       this.options = new Options();
     }
-    this.options.oauth = true;
+    this.options.oauth = oauth;
     return this;
   }
 
@@ -72,6 +72,6 @@ public final class InstitutionsSearchRequest extends BasePublicRequest {
     private boolean includeOptionalMetadata;
     private List<String> countryCodes;
     private Map<String, List<String>> accountFilter;
-    private boolean oauth;
+    private Boolean oauth;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -60,7 +60,7 @@ public final class InstitutionsSearchRequest extends BasePublicRequest {
     return this;
   }
 
-  public InstitutionsSearchRequest withOAuth(oauth boolean) {
+  public InstitutionsSearchRequest withOAuth(boolean oauth) {
     if (this.options == null) {
       this.options = new Options();
     }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -60,9 +60,18 @@ public final class InstitutionsSearchRequest extends BasePublicRequest {
     return this;
   }
 
+  public InstitutionsSearchRequest withOAuth() {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.oauth = true;
+    return this;
+  }
+
   private static class Options {
     private boolean includeOptionalMetadata;
     private List<String> countryCodes;
     private Map<String, List<String>> accountFilter;
+    private boolean oauth;
   }
 }

--- a/src/main/java/com/plaid/client/response/Institution.java
+++ b/src/main/java/com/plaid/client/response/Institution.java
@@ -80,6 +80,7 @@ public final class Institution {
   private String url;
   private String logo;
   private String primaryColor;
+  private boolean oauth;
 
   public String getUrl() {
     return url;
@@ -123,5 +124,9 @@ public final class Institution {
 
   public List<Product> getProducts() {
     return products;
+  }
+
+  public boolean getOAuth() {
+    return oauth;
   }
 }

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import retrofit2.Response;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -68,6 +69,18 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
     // check number returned
     assertEquals(3, response.body().getInstitutions().size());
+  }
+
+  @Test
+  public void testSuccessWithOAuth() throws Exception {
+    Response<InstitutionsGetResponse> response =
+      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth()).execute();
+    assertSuccessResponse(response);
+    List<Institution> institutions = response.body().getInstitutions();
+    assertEquals(3, institutions.size());
+    for (int i = 0; i < institutions.size(); i++) {
+      assertTrue(institutions.get(i).getOAuth());
+    }
   }
 
   @Test

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
@@ -74,12 +74,23 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithOAuth() throws Exception {
     Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth()).execute();
+      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth(true)).execute();
     assertSuccessResponse(response);
     List<Institution> institutions = response.body().getInstitutions();
     assertEquals(3, institutions.size());
     for (int i = 0; i < institutions.size(); i++) {
       assertTrue(institutions.get(i).getOAuth());
+    }
+  }
+
+  @Test
+  public void testSuccessWithoutOAuth() throws Exception {
+    Response<InstitutionsGetResponse> response =
+      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth(false)).execute();
+    assertSuccessResponse(response);
+    List<Institution> institutions = response.body().getInstitutions();
+    for (int i = 0; i < institutions.size(); i++) {
+      assertFalse(institutions.get(i).getOAuth());
     }
   }
 

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -80,6 +80,15 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   }
 
   @Test
+  public void testSuccessWithOAuth() throws Exception {
+    Response<InstitutionsSearchResponse> response =
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Flexible Platypus Open Banking").withCountryCodes(Arrays.asList("GB")).withOAuth()).execute();
+    assertSuccessResponse(response);
+    InstitutionsSearchResponse institutionsSearchResponse = response.body();
+    assertTrue(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
+  }
+
+  @Test
   public void testNoResults() throws Exception {
     Response<InstitutionsSearchResponse> response =
       client().service().institutionsSearch(new InstitutionsSearchRequest("zebra")).execute();

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -82,10 +82,19 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithOAuth() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest("Flexible Platypus Open Banking").withCountryCodes(Arrays.asList("GB")).withOAuth()).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank").withCountryCodes(Arrays.asList("GB")).withOAuth(true)).execute();
     assertSuccessResponse(response);
     InstitutionsSearchResponse institutionsSearchResponse = response.body();
     assertTrue(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
+  }
+
+  @Test
+  public void testSuccessWithoutOAuth() throws Exception {
+    Response<InstitutionsSearchResponse> response =
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank").withCountryCodes(Arrays.asList("GB")).withOAuth(false)).execute();
+    assertSuccessResponse(response);
+    InstitutionsSearchResponse institutionsSearchResponse = response.body();
+    assertFalse(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
   }
 
   @Test

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -15,6 +15,7 @@ import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test


### PR DESCRIPTION
Adds support for a new `oauth` request option for `/institutions/get` and `/institutions/search`, and adds a new `oauth` field to the institution schema returned by `/institutions/get`, `/institutions/get_by_id`, and `/institutions/search`.