### PR TITLE
Add optional user fields to enable attestation in /item/add_token/create

### DIFF
--- a/src/main/java/com/plaid/client/internal/gson/OptionalDateTypeAdapterFactory.java
+++ b/src/main/java/com/plaid/client/internal/gson/OptionalDateTypeAdapterFactory.java
@@ -1,0 +1,54 @@
+package com.plaid.client.internal.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class OptionalDateTypeAdapterFactory implements TypeAdapterFactory {
+  private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.sss'Z'";
+  private final SimpleDateFormat simpleDateFormat;
+
+  public OptionalDateTypeAdapterFactory() {
+    this.simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);
+  }
+
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    if (!Optional.class.isAssignableFrom(type.getRawType())) {
+      return null;
+    }
+    Type maybeDateType = ((ParameterizedType) type.getType()).getActualTypeArguments()[0];
+    if (!Date.class.isAssignableFrom(TypeToken.get(maybeDateType).getRawType())) {
+      return null;
+    }
+
+    return new TypeAdapter<T>() {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
+        if (((Optional) value).isPresent()) {
+          Date dateValue = (Date) (((Optional) value).get());
+          // date formatters not thread safe :'(
+          synchronized (simpleDateFormat) {
+            out.value(simpleDateFormat.format(dateValue));
+          }
+        } else {
+          out.nullValue();
+        }
+      }
+
+      @Override
+      public T read(JsonReader in) throws IOException {
+        throw new UnsupportedOperationException("read() is not implemented");
+      }
+    };
+  }
+}

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -19,7 +19,11 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
 
   public static class User {
     private String clientUserId;
-    private Optional<Options> options = Optional.empty();
+    private Optional<String> legalName = Optional.empty();
+    private Optional<String> phoneNumber = Optional.empty();
+    private Optional<String> emailAddress = Optional.empty();
+    private Optional<Date> phoneNumberVerifiedTime = Optional.empty();
+    private Optional<Date> emailAddressVerifiedTime = Optional.empty();
 
     public User(String clientUserId) {
       Util.notNull(clientUserId, "clientUserId");
@@ -28,49 +32,36 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
 
     public User withLegalName(String legalName) {
       Util.notNull(legalName, "legalName");
-      options = options.orElse(new Options());
-      options.get().legalName = legalName;
+      legalName.get() = legalName
       return this;
     }
 
     public User withPhoneNumber(String phoneNumber) {
       Util.notNull(phoneNumber, "phoneNumber");
-      options = options.orElse(new Options());
-      options.get().phoneNumber = phoneNumber;
+      phoneNumber.get() = phoneNumber;
       return this;
     }
 
     public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime) {
       Util.notNull(phoneNumber, "phoneNumber");
       Util.notNull(verifiedTime, "verifiedTime");
-      options = options.orElse(new Options());
-      options.get().phoneNumber = phoneNumber;
-      options.get().phoneNumberVerifiedTime = verifiedTime;
+      phoneNumber.get() = phoneNumber;
+      phoneNumberVerifiedTime.get() = verifiedTime;
       return this;
     }
 
     public User withEmailAddress(String emailAddress) {
       Util.notNull(emailAddress, "emailAddress");
-      options = options.orElse(new Options());
-      options.get().emailAddress = emailAddress;
+      emailAddress.get() = emailAddress;
       return this;
     }
 
     public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime) {
       Util.notNull(emailAddress, "emailAddress");
       Util.notNull(verifiedTime, "verifiedTime");
-      options = options.orElse(new Options());
-      options.get().emailAddress = emailAddress;
-      options.get().emailAddressVerifiedTime = verifiedTime;
+      emailAddress.get() = emailAddress;
+      emailAddressVerifiedTime.get() = verifiedTime;
       return this;
-    }
-
-    private static class Options {
-      private String legalName;
-      private String phoneNumber;
-      private String emailAddress;
-      private Date phoneNumberVerifiedTime;
-      private Date emailAddressVerifiedTime;
     }
   }
 }

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -1,7 +1,7 @@
 package com.plaid.client.request;
 
 import com.google.gson.annotations.JsonAdapter;
-import com.plaid.client.internal.gson.DateOnlyTypeAdapterFactory;
+import com.plaid.client.internal.gson.OptionalDateTypeAdapterFactory;
 import com.plaid.client.internal.gson.Optional;
 import com.plaid.client.internal.Util;
 import com.plaid.client.request.common.BaseClientRequest;
@@ -24,9 +24,9 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
     private Optional<String> legalName = Optional.empty();
     private Optional<String> phoneNumber = Optional.empty();
     private Optional<String> emailAddress = Optional.empty();
-    @JsonAdapter(DateOnlyTypeAdapterFactory.class)
+    @JsonAdapter(OptionalDateTypeAdapterFactory.class)
     private Optional<Date> phoneNumberVerifiedTime = Optional.empty();
-    @JsonAdapter(DateOnlyTypeAdapterFactory.class)
+    @JsonAdapter(OptionalDateTypeAdapterFactory.class)
     private Optional<Date> emailAddressVerifiedTime = Optional.empty();
 
     public User(String clientUserId) {

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -1,5 +1,6 @@
 package com.plaid.client.request;
 
+import com.plaid.client.internal.gson.Optional;
 import com.plaid.client.internal.Util;
 import com.plaid.client.request.common.BaseClientRequest;
 
@@ -16,10 +17,58 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
 
   public static class User {
     private String clientUserId;
+    private Optional<Options> options = Optional.empty();
 
     public User(String clientUserId) {
       Util.notNull(clientUserId, "clientUserId");
       this.clientUserId = clientUserId;
+    }
+
+    public User withLegalName(String legalName)
+      notNull(legalName, "legalName");
+      options = options.orElse(new Options());
+      userOptions.get().legalName = legalName;
+      return this;
+    }
+
+    public User withPhoneNumber(String phoneNumber)
+      notNull(phoneNumber, "phoneNumber");
+      options = options.orElse(new Options());
+      options.get().phoneNumber = phoneNumber;
+      return this;
+    }
+
+    public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime)
+      notNull(phoneNumber, "phoneNumber");
+      notNull(verifiedTime, "verifiedTime");
+      options = options.orElse(new Options());
+      options.get().phoneNumber = phoneNumber;
+      options.get().phoneNumberVerifiedTime = verifiedTime;
+      return this;
+    }
+
+    public User withEmailAddress(String emailAddress)
+      notNull(emailAddress, "emailAddress");
+      options = options.orElse(new Options());
+      options.get().emailAddress = emailAddress;
+      return this;
+    }
+
+    public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime)
+      notNull(emailAddress, "emailAddress");
+      notNull(verifiedTime, "verifiedTime");
+      options = options.orElse(new Options());
+      options.get().emailAddress = emailAddress;
+      options.get().emailAddressVerifiedTime = verifiedTime;
+      return this;
+    }
+
+    private static class Options {
+      private String legalName;
+      private String phoneNumber;
+      private String emailAddress;
+      private Date phoneNumberVerifiedTime;
+      private Date emailAddressVerifiedTime;
     }
   }
 }

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -32,35 +32,35 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
 
     public User withLegalName(String legalName) {
       Util.notNull(legalName, "legalName");
-      legalName.get() = legalName
+      this.legalName = Optional.of(legalName);
       return this;
     }
 
     public User withPhoneNumber(String phoneNumber) {
       Util.notNull(phoneNumber, "phoneNumber");
-      phoneNumber.get() = phoneNumber;
+      this.phoneNumber = Optional.of(phoneNumber);
       return this;
     }
 
     public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime) {
       Util.notNull(phoneNumber, "phoneNumber");
       Util.notNull(verifiedTime, "verifiedTime");
-      phoneNumber.get() = phoneNumber;
-      phoneNumberVerifiedTime.get() = verifiedTime;
+      this.phoneNumber = Optional.of(phoneNumber);
+      this.phoneNumberVerifiedTime = Optional.of(verifiedTime);
       return this;
     }
 
     public User withEmailAddress(String emailAddress) {
       Util.notNull(emailAddress, "emailAddress");
-      emailAddress.get() = emailAddress;
+      this.emailAddress = Optional.of(emailAddress);
       return this;
     }
 
     public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime) {
       Util.notNull(emailAddress, "emailAddress");
       Util.notNull(verifiedTime, "verifiedTime");
-      emailAddress.get() = emailAddress;
-      emailAddressVerifiedTime.get() = verifiedTime;
+      this.emailAddress = Optional.of(emailAddress);
+      this.emailAddressVerifiedTime = Optional.of(verifiedTime);
       return this;
     }
   }

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -4,6 +4,8 @@ import com.plaid.client.internal.gson.Optional;
 import com.plaid.client.internal.Util;
 import com.plaid.client.request.common.BaseClientRequest;
 
+import java.util.Date;
+
 /**
  * Request for the /item/add_token/create endpoint.
  */

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -27,22 +27,22 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
     }
 
     public User withLegalName(String legalName) {
-      notNull(legalName, "legalName");
+      Util.notNull(legalName, "legalName");
       options = options.orElse(new Options());
-      userOptions.get().legalName = legalName;
+      options.get().legalName = legalName;
       return this;
     }
 
     public User withPhoneNumber(String phoneNumber) {
-      notNull(phoneNumber, "phoneNumber");
+      Util.notNull(phoneNumber, "phoneNumber");
       options = options.orElse(new Options());
       options.get().phoneNumber = phoneNumber;
       return this;
     }
 
     public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime) {
-      notNull(phoneNumber, "phoneNumber");
-      notNull(verifiedTime, "verifiedTime");
+      Util.notNull(phoneNumber, "phoneNumber");
+      Util.notNull(verifiedTime, "verifiedTime");
       options = options.orElse(new Options());
       options.get().phoneNumber = phoneNumber;
       options.get().phoneNumberVerifiedTime = verifiedTime;
@@ -50,15 +50,15 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
     }
 
     public User withEmailAddress(String emailAddress) {
-      notNull(emailAddress, "emailAddress");
+      Util.notNull(emailAddress, "emailAddress");
       options = options.orElse(new Options());
       options.get().emailAddress = emailAddress;
       return this;
     }
 
     public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime) {
-      notNull(emailAddress, "emailAddress");
-      notNull(verifiedTime, "verifiedTime");
+      Util.notNull(emailAddress, "emailAddress");
+      Util.notNull(verifiedTime, "verifiedTime");
       options = options.orElse(new Options());
       options.get().emailAddress = emailAddress;
       options.get().emailAddressVerifiedTime = verifiedTime;

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -1,5 +1,7 @@
 package com.plaid.client.request;
 
+import com.google.gson.annotations.JsonAdapter;
+import com.plaid.client.internal.gson.DateOnlyTypeAdapterFactory;
 import com.plaid.client.internal.gson.Optional;
 import com.plaid.client.internal.Util;
 import com.plaid.client.request.common.BaseClientRequest;
@@ -22,7 +24,9 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
     private Optional<String> legalName = Optional.empty();
     private Optional<String> phoneNumber = Optional.empty();
     private Optional<String> emailAddress = Optional.empty();
+    @JsonAdapter(DateOnlyTypeAdapterFactory.class)
     private Optional<Date> phoneNumberVerifiedTime = Optional.empty();
+    @JsonAdapter(DateOnlyTypeAdapterFactory.class)
     private Optional<Date> emailAddressVerifiedTime = Optional.empty();
 
     public User(String clientUserId) {

--- a/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
+++ b/src/main/java/com/plaid/client/request/ItemAddTokenCreateRequest.java
@@ -24,21 +24,21 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
       this.clientUserId = clientUserId;
     }
 
-    public User withLegalName(String legalName)
+    public User withLegalName(String legalName) {
       notNull(legalName, "legalName");
       options = options.orElse(new Options());
       userOptions.get().legalName = legalName;
       return this;
     }
 
-    public User withPhoneNumber(String phoneNumber)
+    public User withPhoneNumber(String phoneNumber) {
       notNull(phoneNumber, "phoneNumber");
       options = options.orElse(new Options());
       options.get().phoneNumber = phoneNumber;
       return this;
     }
 
-    public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime)
+    public User withVerifiedPhoneNumber(String phoneNumber, Date verifiedTime) {
       notNull(phoneNumber, "phoneNumber");
       notNull(verifiedTime, "verifiedTime");
       options = options.orElse(new Options());
@@ -47,14 +47,14 @@ public final class ItemAddTokenCreateRequest extends BaseClientRequest {
       return this;
     }
 
-    public User withEmailAddress(String emailAddress)
+    public User withEmailAddress(String emailAddress) {
       notNull(emailAddress, "emailAddress");
       options = options.orElse(new Options());
       options.get().emailAddress = emailAddress;
       return this;
     }
 
-    public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime)
+    public User withVerifiedEmailAddress(String emailAddress, Date verifiedTime) {
       notNull(emailAddress, "emailAddress");
       notNull(verifiedTime, "verifiedTime");
       options = options.orElse(new Options());

--- a/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
+++ b/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
@@ -44,12 +44,31 @@ public class ItemAddTokenCreateTest extends AbstractItemIntegrationTest {
     String legalName = "John Doe";
     String phoneNumber = "+1 415 555 0123";
     String emailAddress = "example@plaid.com";
-    Date verifiedTime = new Date();
     ItemAddTokenCreateRequest.User user =  new ItemAddTokenCreateRequest
       .User(clientUserId)
       .withLegalName(legalName)
-      .withVerifiedPhoneNumber(phoneNumber, verifiedTime)
+      .withPhoneNumber(phoneNumber)
       .withEmailAddress(emailAddress);
+    Response<ItemAddTokenCreateResponse> response =
+      client().service().itemAddTokenCreate(
+        new ItemAddTokenCreateRequest(user)).execute();
+
+    assertSuccessResponse(response);
+    assertNotNull(response.body().getAddToken());
+    assertTrue(response.body().getExpiration().after(new Date()));
+  }
+
+  @Test
+  public void testSuccessWithVerifiedUserOptions() throws Exception {
+    String clientUserId = Long.toString((new Date()).getTime());
+    String legalName = "John Doe";
+    String phoneNumber = "+1 415 555 0123";
+    String emailAddress = "example@plaid.com";
+    Date verifiedTime = new Date();
+    ItemAddTokenCreateRequest.User user =  new ItemAddTokenCreateRequest
+      .User(clientUserId)
+      .withVerifiedPhoneNumber(phoneNumber, verifiedTime)
+      .withVerifiedEmailAddress(emailAddress, verifiedTime);
     Response<ItemAddTokenCreateResponse> response =
       client().service().itemAddTokenCreate(
         new ItemAddTokenCreateRequest(user)).execute();

--- a/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
+++ b/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
@@ -45,9 +45,11 @@ public class ItemAddTokenCreateTest extends AbstractItemIntegrationTest {
     String phoneNumber = "+1 415 555 0123";
     String emailAddress = "example@plaid.com";
     Date verifiedTime = new Date();
-    ItemAddTokenCreateRequest.User user =  new ItemAddTokenCreateRequest.User(
-      clientUserId).withLegalName(legalName).withVerifiedPhoneNumber(
-        phoneNumber, verifiedTime).withEmailAddress(emailAddress);
+    ItemAddTokenCreateRequest.User user =  new ItemAddTokenCreateRequest
+      .User(clientUserId)
+      .withLegalName(legalName)
+      .withVerifiedPhoneNumber(phoneNumber, verifiedTime)
+      .withEmailAddress(emailAddress);
     Response<ItemAddTokenCreateResponse> response =
       client().service().itemAddTokenCreate(
         new ItemAddTokenCreateRequest(user)).execute();

--- a/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
+++ b/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
@@ -61,7 +61,6 @@ public class ItemAddTokenCreateTest extends AbstractItemIntegrationTest {
   @Test
   public void testSuccessWithVerifiedUserOptions() throws Exception {
     String clientUserId = Long.toString((new Date()).getTime());
-    String legalName = "John Doe";
     String phoneNumber = "+1 415 555 0123";
     String emailAddress = "example@plaid.com";
     Date verifiedTime = new Date();

--- a/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
+++ b/src/test/java/com/plaid/client/integration/ItemAddTokenCreateTest.java
@@ -37,4 +37,23 @@ public class ItemAddTokenCreateTest extends AbstractItemIntegrationTest {
     assertNotNull(response.body().getAddToken());
     assertTrue(response.body().getExpiration().after(new Date()));
   }
+
+  @Test
+  public void testSuccessWithUserOptions() throws Exception {
+    String clientUserId = Long.toString((new Date()).getTime());
+    String legalName = "John Doe";
+    String phoneNumber = "+1 415 555 0123";
+    String emailAddress = "example@plaid.com";
+    Date verifiedTime = new Date();
+    ItemAddTokenCreateRequest.User user =  new ItemAddTokenCreateRequest.User(
+      clientUserId).withLegalName(legalName).withVerifiedPhoneNumber(
+        phoneNumber, verifiedTime).withEmailAddress(emailAddress);
+    Response<ItemAddTokenCreateResponse> response =
+      client().service().itemAddTokenCreate(
+        new ItemAddTokenCreateRequest(user)).execute();
+
+    assertSuccessResponse(response);
+    assertNotNull(response.body().getAddToken());
+    assertTrue(response.body().getExpiration().after(new Date()));
+  }
 }


### PR DESCRIPTION
Similar to https://github.com/plaid/plaid-python/commit/42066b8118e92c7b2de25d7a4e3993a3d1660552, this PR adds support for including additional user data when creating item add tokens. 