### PR TITLE
make versions consistent between retrofit and okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,22 +200,22 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
-      <version>2.7.2</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-gson</artifactId>
-      <version>2.7.2</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.4.1</version>
+      <version>3.14.9</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>4.4.1</version>
+      <version>3.14.9</version>
     </dependency>
 
     <!-- Test Deps -->


### PR DESCRIPTION
retrofit2 was referencing a version of okhttp3 that was older than the actual version we were referencing.

okhttp4 4.x.x also references a bunch of kotlin std libraries that make dependency management more difficult for us.

