### PR TITLE
Fix broken link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ try {
 If you're looking for a Java client that works with the legacy Plaid API, use
 versions of `plaid-java` before `2.1.0`. The API and client are not backwards-compatible.
 
-[version-changelog]: https://plaid.com/docs/version-changelog
+[version-changelog]: https://plaid.com/docs/api-upgrades/#version-changelog
 [api-version-2018-05-22]: https://plaid.com/docs/api-upgrades#2018-05-22
 [api-version-2019-05-29]: https://plaid.com/docs/api-upgrades#2019-05-29


### PR DESCRIPTION
The link to the changelog is currently broken and it is a confusing user experience.

This fixes this link to the appropriate place in the Plaid docs