### PR TITLE
Add subtype to InvestmentTransactions

### DIFF
--- a/src/main/java/com/plaid/client/response/InvestmentsTransactionsGetResponse.java
+++ b/src/main/java/com/plaid/client/response/InvestmentsTransactionsGetResponse.java
@@ -48,6 +48,7 @@ public class InvestmentsTransactionsGetResponse extends BaseResponse {
     private String isoCurrencyCode;
     private String unofficialCurrencyCode;
     private String cancelTransactionId;
+    private String subtype;
 
     public String getInvestmentTransactionId() {
       return investmentTransactionId;


### PR DESCRIPTION
We are missing subtypes from InvestmentTransactions, even though they should already be returned by the API