### PR TITLE
Add country codes to institutions/ routes

### DIFF
--- a/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
@@ -2,7 +2,10 @@ package com.plaid.client.request;
 
 import com.plaid.client.request.common.BaseClientRequest;
 
+import static com.plaid.client.internal.Util.notEmpty;
 import static com.plaid.client.internal.Util.notNull;
+
+import java.util.List;
 
 /**
  * Request for the /institutions/get_by_id endpoint.
@@ -10,12 +13,15 @@ import static com.plaid.client.internal.Util.notNull;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsGetByIdRequest extends BaseClientRequest {
+  private List<String> countryCodes;
   private String institutionId;
   private Options options;
 
-  public InstitutionsGetByIdRequest(String institutionId) {
+  public InstitutionsGetByIdRequest(List<String> countryCodes, String institutionId) {
+    notEmpty(countryCodes, "countryCodes");
     notNull(institutionId, "institutionId");
 
+    this.countryCodes = countryCodes;
     this.institutionId = institutionId;
   }
 

--- a/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
@@ -13,16 +13,16 @@ import java.util.List;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsGetByIdRequest extends BaseClientRequest {
-  private List<String> countryCodes;
   private String institutionId;
+  private List<String> countryCodes;
   private Options options;
 
-  public InstitutionsGetByIdRequest(List<String> countryCodes, String institutionId) {
-    notEmpty(countryCodes, "countryCodes");
+  public InstitutionsGetByIdRequest(String institutionId, List<String> countryCodes) {
     notNull(institutionId, "institutionId");
+    notEmpty(countryCodes, "countryCodes");
 
-    this.countryCodes = countryCodes;
     this.institutionId = institutionId;
+    this.countryCodes = countryCodes;
   }
 
   public InstitutionsGetByIdRequest withIncludeOptionalMetadata(boolean includeOptionalMetadata) {

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -14,19 +14,19 @@ import static com.plaid.client.internal.Util.notEmpty;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsGetRequest extends BaseClientRequest {
-  private List<String> countryCodes;
   private Integer count;
   private Integer offset;
+  private List<String> countryCodes;
   private Options options;
 
-  public InstitutionsGetRequest(List<String> countryCodes, Integer count, Integer offset) {
-    notEmpty(countryCodes, "countryCodes");
+  public InstitutionsGetRequest(Integer count, Integer offset, List<String> countryCodes) {
     isBetween(count, 1, 500, "count");
     isBetween(offset, 0, Integer.MAX_VALUE, "offset");
+    notEmpty(countryCodes, "countryCodes");
 
-    this.countryCodes = countryCodes;
     this.count = count;
     this.offset = offset;
+    this.countryCodes = countryCodes;
   }
 
   public InstitutionsGetRequest withProducts(List<Product> products) {

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -6,7 +6,7 @@ import com.plaid.client.request.common.Product;
 import java.util.List;
 
 import static com.plaid.client.internal.Util.isBetween;
-import static com.plaid.client.internal.Util.notNull;
+import static com.plaid.client.internal.Util.notEmpty;
 
 /**
  * Request for the /institutions/get endpoint.
@@ -14,14 +14,17 @@ import static com.plaid.client.internal.Util.notNull;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsGetRequest extends BaseClientRequest {
+  private List<String> countryCodes;
   private Integer count;
   private Integer offset;
   private Options options;
 
-  public InstitutionsGetRequest(Integer count, Integer offset) {
+  public InstitutionsGetRequest(List<String> countryCodes, Integer count, Integer offset) {
+    notEmpty(countryCodes, "countryCodes");
     isBetween(count, 1, 500, "count");
     isBetween(offset, 0, Integer.MAX_VALUE, "offset");
 
+    this.countryCodes = countryCodes;
     this.count = count;
     this.offset = offset;
   }
@@ -42,14 +45,6 @@ public class InstitutionsGetRequest extends BaseClientRequest {
     return this;
   }
 
-  public InstitutionsGetRequest withCountryCodes(List<String> countryCodes) {
-    if (this.options == null) {
-      this.options = new Options();
-    }
-    this.options.countryCodes = countryCodes;
-    return this;
-  }
-
   public InstitutionsGetRequest withOAuth(boolean oauth) {
     if (this.options == null) {
       this.options = new Options();
@@ -61,7 +56,6 @@ public class InstitutionsGetRequest extends BaseClientRequest {
   private static class Options {
     private List<Product> products;
     private boolean includeOptionalMetadata;
-    private List<String> countryCodes;
     private Boolean oauth;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -18,12 +18,16 @@ import static com.plaid.client.internal.Util.notNull;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsSearchRequest extends BaseClientRequest {
+  private List<String> countryCodes;
   private String query;
   private RequiredField<List<Product>> products = RequiredField.empty();
   private Options options;
 
-  public InstitutionsSearchRequest(String query) {
+  public InstitutionsSearchRequest(List<String> countryCodes, String query) {
+    notEmpty(countryCodes, "countryCodes");
     notNull(query, "query");
+    
+    this.countryCodes = countryCodes;
     this.query = query;
   }
 
@@ -41,14 +45,6 @@ public class InstitutionsSearchRequest extends BaseClientRequest {
       this.options = new Options();
     }
     this.options.includeOptionalMetadata = includeOptionalMetadata;
-    return this;
-  }
-
-  public InstitutionsSearchRequest withCountryCodes(List<String> countryCodes) {
-    if (this.options == null) {
-      this.options = new Options();
-    }
-    this.options.countryCodes = countryCodes;
     return this;
   }
 
@@ -70,7 +66,6 @@ public class InstitutionsSearchRequest extends BaseClientRequest {
 
   private static class Options {
     private boolean includeOptionalMetadata;
-    private List<String> countryCodes;
     private Map<String, List<String>> accountFilter;
     private Boolean oauth;
   }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -18,17 +18,17 @@ import static com.plaid.client.internal.Util.notNull;
  * @see <a href="https://plaid.com/docs/api/">https://plaid.com/docs/api</a>
  */
 public class InstitutionsSearchRequest extends BaseClientRequest {
-  private List<String> countryCodes;
   private String query;
   private RequiredField<List<Product>> products = RequiredField.empty();
+  private List<String> countryCodes;
   private Options options;
 
-  public InstitutionsSearchRequest(List<String> countryCodes, String query) {
-    notEmpty(countryCodes, "countryCodes");
+  public InstitutionsSearchRequest(String query, List<String> countryCodes) {
     notNull(query, "query");
-    
-    this.countryCodes = countryCodes;
+    notEmpty(countryCodes, "countryCodes");
+
     this.query = query;
+    this.countryCodes = countryCodes;
   }
 
   public InstitutionsSearchRequest withProducts(Product... products) {

--- a/src/test/java/com/plaid/client/PlaidClientBuilderTest.java
+++ b/src/test/java/com/plaid/client/PlaidClientBuilderTest.java
@@ -4,11 +4,13 @@ import com.plaid.client.request.InstitutionsSearchRequest;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public class PlaidClientBuilderTest {
-  private static final InstitutionsSearchRequest INSTITUTIONS_SEARCH_REQUEST = new InstitutionsSearchRequest("q");
+  private static final InstitutionsSearchRequest INSTITUTIONS_SEARCH_REQUEST = new InstitutionsSearchRequest(Arrays.asList("US"), "q");
   private static final String CLIENT_ID = "theclientid";
   private static final String SECRET = "thesecret";
 

--- a/src/test/java/com/plaid/client/PlaidClientBuilderTest.java
+++ b/src/test/java/com/plaid/client/PlaidClientBuilderTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public class PlaidClientBuilderTest {
-  private static final InstitutionsSearchRequest INSTITUTIONS_SEARCH_REQUEST = new InstitutionsSearchRequest(Arrays.asList("US"), "q");
+  private static final InstitutionsSearchRequest INSTITUTIONS_SEARCH_REQUEST = new InstitutionsSearchRequest("q", Arrays.asList("US"));
   private static final String CLIENT_ID = "theclientid";
   private static final String SECRET = "thesecret";
 

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
@@ -22,12 +22,6 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
     assertSuccessResponse(response);
 
     Institution institution = response.body().getInstitution();
-    assertFalse(institution.getCredentials().isEmpty());
-    for (Institution.Credential c : institution.getCredentials()) {
-      assertNotNull(c.getLabel());
-      assertNotNull(c.getType());
-      assertNotNull(c.getName());
-    }
     assertIsTartanBank(institution);
   }
 
@@ -42,13 +36,6 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
     assertSuccessResponse(response);
 
     Institution institution = response.body().getInstitution();
-    assertFalse(institution.getCredentials().isEmpty());
-    for (Institution.Credential c : institution.getCredentials()) {
-      assertNotNull(c.getLabel());
-      assertNotNull(c.getType());
-      assertNotNull(c.getName());
-    }
-
     assertIsTartanBank(institution);
 
     assertEquals("https://www.plaid.com/", institution.getUrl());
@@ -66,13 +53,6 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
     assertSuccessResponse(response);
 
     Institution institution = response.body().getInstitution();
-    assertFalse(institution.getCredentials().isEmpty());
-    for (Institution.Credential c : institution.getCredentials()) {
-      assertNotNull(c.getLabel());
-      assertNotNull(c.getType());
-      assertNotNull(c.getName());
-    }
-
     assertIsTartanBank(institution);
 
     assertEquals(null, institution.getUrl());
@@ -113,9 +93,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   }
 
   private void assertIsTartanBank(Institution institution) {
-    assertTrue(institution.hasMfa());
     assertEquals(TARTAN_BANK_INSTITUTION_ID, institution.getInstitutionId());
-    assertEquals(Arrays.asList("code", "list", "questions", "selections"), institution.getMfa());
     assertEquals("Tartan Bank", institution.getName());
     assertEquals(Arrays.asList(
       Product.ASSETS,
@@ -133,9 +111,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   }
 
   private void assertIsFirstPlatypusBank(Institution institution) {
-    assertTrue(institution.hasMfa());
     assertEquals(FIRST_PLATYPUS_BANK_INSTITUTION_ID, institution.getInstitutionId());
-    assertEquals(Arrays.asList("code", "list", "questions", "selections"), institution.getMfa());
     assertEquals("First Platypus Bank", institution.getName());
     assertEquals(Arrays.asList(
       Product.ASSETS,

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import retrofit2.Response;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -17,7 +16,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID))
+      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID, Arrays.asList("US")))
       .execute();
 
     assertSuccessResponse(response);
@@ -36,7 +35,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
     Response<InstitutionsGetByIdResponse> response =
       client().service().institutionsGetById(
-        new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).withIncludeOptionalMetadata(
+        new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID, Arrays.asList("US")).withIncludeOptionalMetadata(
           true))
         .execute();
 
@@ -60,7 +59,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID, Arrays.asList("US")).
         withIncludeOptionalMetadata(false))
       .execute();
 
@@ -84,7 +83,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeStatusTrue() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), FIRST_PLATYPUS_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(FIRST_PLATYPUS_BANK_INSTITUTION_ID, Arrays.asList("US")).
         withIncludeStatus(true))
       .execute();
 
@@ -102,7 +101,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeStatusFalse() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID, Arrays.asList("US")).
         withIncludeStatus(false))
       .execute();
 
@@ -156,7 +155,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testInvalidInstitution() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().institutionsGetById(
-      new InstitutionsGetByIdRequest(Arrays.asList("US"), "notreal"))
+      new InstitutionsGetByIdRequest("notreal", Arrays.asList("US")))
       .execute();
 
     assertErrorResponse(response, ErrorResponse.ErrorType.INVALID_INPUT, "INVALID_INSTITUTION");

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import retrofit2.Response;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -16,7 +17,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID))
+      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID))
       .execute();
 
     assertSuccessResponse(response);
@@ -35,7 +36,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
     Response<InstitutionsGetByIdResponse> response =
       client().service().institutionsGetById(
-        new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID).withIncludeOptionalMetadata(
+        new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).withIncludeOptionalMetadata(
           true))
         .execute();
 
@@ -59,7 +60,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).
         withIncludeOptionalMetadata(false))
       .execute();
 
@@ -83,7 +84,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeStatusTrue() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(FIRST_PLATYPUS_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), FIRST_PLATYPUS_BANK_INSTITUTION_ID).
         withIncludeStatus(true))
       .execute();
 
@@ -101,7 +102,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeStatusFalse() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().
-      institutionsGetById(new InstitutionsGetByIdRequest(TARTAN_BANK_INSTITUTION_ID).
+      institutionsGetById(new InstitutionsGetByIdRequest(Arrays.asList("US"), TARTAN_BANK_INSTITUTION_ID).
         withIncludeStatus(false))
       .execute();
 
@@ -155,7 +156,7 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
   @Test
   public void testInvalidInstitution() throws Exception {
     Response<InstitutionsGetByIdResponse> response = client().service().institutionsGetById(
-      new InstitutionsGetByIdRequest("notreal"))
+      new InstitutionsGetByIdRequest(Arrays.asList("US"), "notreal"))
       .execute();
 
     assertErrorResponse(response, ErrorResponse.ErrorType.INVALID_INPUT, "INVALID_INSTITUTION");

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
@@ -1,22 +1,27 @@
 package com.plaid.client.integration;
 
-import com.plaid.client.request.InstitutionsGetRequest;
-import com.plaid.client.request.common.Product;
-import com.plaid.client.response.Institution;
-import com.plaid.client.response.InstitutionsGetResponse;
-import org.junit.Test;
-import retrofit2.Response;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import com.plaid.client.request.InstitutionsGetRequest;
+import com.plaid.client.request.common.Product;
+import com.plaid.client.response.Institution;
+import com.plaid.client.response.InstitutionsGetResponse;
+
+import org.junit.Test;
+
+import retrofit2.Response;
 
 public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(3, 0)).execute();
+      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0)).execute();
 
     assertSuccessResponse(response);
 
@@ -27,8 +32,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithProducts() throws Exception {
     Response<InstitutionsGetResponse> response =
-    client().service().institutionsGet(new InstitutionsGetRequest(3, 0).
-      withCountryCodes(Arrays.asList("US")).
+    client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).
       withProducts(Arrays.asList(Product.IDENTITY))).
     execute();
 
@@ -41,7 +45,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
     Response<InstitutionsGetResponse> response =
-        client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withIncludeOptionalMetadata(true)).execute();
+        client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).withIncludeOptionalMetadata(true)).execute();
 
     assertSuccessResponse(response);
 
@@ -52,7 +56,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
     Response<InstitutionsGetResponse> response =
-        client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withIncludeOptionalMetadata(false)).execute();
+        client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).withIncludeOptionalMetadata(false)).execute();
 
     assertSuccessResponse(response);
 
@@ -63,7 +67,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithCountryCodes() throws Exception {
     Response<InstitutionsGetResponse> response =
-    client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("US"))).execute();
+    client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0)).execute();
 
     assertSuccessResponse(response);
 
@@ -74,7 +78,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithOAuth() throws Exception {
     Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth(true)).execute();
+      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("GB"), 3, 0).withOAuth(true)).execute();
     assertSuccessResponse(response);
     List<Institution> institutions = response.body().getInstitutions();
     assertEquals(3, institutions.size());
@@ -86,7 +90,7 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithoutOAuth() throws Exception {
     Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(3, 0).withCountryCodes(Arrays.asList("GB")).withOAuth(false)).execute();
+      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("GB"), 3, 0).withOAuth(false)).execute();
     assertSuccessResponse(response);
     List<Institution> institutions = response.body().getInstitutions();
     for (int i = 0; i < institutions.size(); i++) {
@@ -97,17 +101,17 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testRequestValidation() throws Exception {
     try {
-      new InstitutionsGetRequest(0, 0);
+      new InstitutionsGetRequest(Arrays.asList("US"), 0, 0);
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }
     try {
-      new InstitutionsGetRequest(501, 0);
+      new InstitutionsGetRequest(Arrays.asList("US"), 501, 0);
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }
     try {
-      new InstitutionsGetRequest(1, -1);
+      new InstitutionsGetRequest(Arrays.asList("US"), 1, -1);
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetTest.java
@@ -20,8 +20,8 @@ import retrofit2.Response;
 public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
-    Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("US"))).execute();
 
     assertSuccessResponse(response);
 
@@ -31,10 +31,10 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithProducts() throws Exception {
-    Response<InstitutionsGetResponse> response =
-    client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).
-      withProducts(Arrays.asList(Product.IDENTITY))).
-    execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(
+            new InstitutionsGetRequest(3, 0, Arrays.asList("US")).withProducts(Arrays.asList(Product.IDENTITY)))
+        .execute();
 
     assertSuccessResponse(response);
 
@@ -44,8 +44,9 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
-    Response<InstitutionsGetResponse> response =
-        client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).withIncludeOptionalMetadata(true)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("US")).withIncludeOptionalMetadata(true))
+        .execute();
 
     assertSuccessResponse(response);
 
@@ -55,8 +56,9 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
-    Response<InstitutionsGetResponse> response =
-        client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0).withIncludeOptionalMetadata(false)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("US")).withIncludeOptionalMetadata(false))
+        .execute();
 
     assertSuccessResponse(response);
 
@@ -66,8 +68,8 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithCountryCodes() throws Exception {
-    Response<InstitutionsGetResponse> response =
-    client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("US"), 3, 0)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("US"))).execute();
 
     assertSuccessResponse(response);
 
@@ -77,8 +79,8 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithOAuth() throws Exception {
-    Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("GB"), 3, 0).withOAuth(true)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("GB")).withOAuth(true)).execute();
     assertSuccessResponse(response);
     List<Institution> institutions = response.body().getInstitutions();
     assertEquals(3, institutions.size());
@@ -89,8 +91,8 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
 
   @Test
   public void testSuccessWithoutOAuth() throws Exception {
-    Response<InstitutionsGetResponse> response =
-      client().service().institutionsGet(new InstitutionsGetRequest(Arrays.asList("GB"), 3, 0).withOAuth(false)).execute();
+    Response<InstitutionsGetResponse> response = client().service()
+        .institutionsGet(new InstitutionsGetRequest(3, 0, Arrays.asList("GB")).withOAuth(false)).execute();
     assertSuccessResponse(response);
     List<Institution> institutions = response.body().getInstitutions();
     for (int i = 0; i < institutions.size(); i++) {
@@ -101,17 +103,17 @@ public class InstitutionsGetTest extends AbstractIntegrationTest {
   @Test
   public void testRequestValidation() throws Exception {
     try {
-      new InstitutionsGetRequest(Arrays.asList("US"), 0, 0);
+      new InstitutionsGetRequest(0, 0, Arrays.asList("US"));
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }
     try {
-      new InstitutionsGetRequest(Arrays.asList("US"), 501, 0);
+      new InstitutionsGetRequest(501, 0, Arrays.asList("US"));
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }
     try {
-      new InstitutionsGetRequest(Arrays.asList("US"), 1, -1);
+      new InstitutionsGetRequest(1, -1, Arrays.asList("US"));
       fail("should have thrown exception");
     } catch (IllegalArgumentException e) {
     }

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -21,7 +21,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest("t").withProducts(Product.IDENTITY)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withProducts(Product.IDENTITY)).execute();
 
     assertSuccessResponse(response);
   }
@@ -29,7 +29,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest("t").withIncludeOptionalMetadata(true)).execute();
+        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withIncludeOptionalMetadata(true)).execute();
 
     assertSuccessResponse(response);
 
@@ -41,7 +41,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest("t").withIncludeOptionalMetadata(false)).execute();
+        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withIncludeOptionalMetadata(false)).execute();
 
     assertSuccessResponse(response);
 
@@ -52,25 +52,12 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   }
 
   @Test
-  public void testSuccessWithCountryCodes() throws Exception {
-    Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest("t").withCountryCodes(Arrays.asList("US"))).execute();
-
-    assertSuccessResponse(response);
-
-    InstitutionsSearchResponse institutionsSearchResponse = response.body();
-
-    assertEquals(institutionsSearchResponse.getInstitutions().get(0).getCountryCodes(), Arrays.asList("US"));
-  }
-
-  @Test
   public void testSuccessWithAccountFilter() throws Exception {
     Map<String, List<String>> accountFilter = new HashMap<>();
     accountFilter.put("loan", Arrays.asList("student"));
 
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest("wells")
-          .withCountryCodes(Arrays.asList("US"))
+        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "wells")
           .withAccountFilter(accountFilter)
           .withProducts(Product.LIABILITIES)
         ).execute();
@@ -83,7 +70,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithOAuth() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank").withCountryCodes(Arrays.asList("GB")).withOAuth(true)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("GB"), "Bank").withOAuth(true)).execute();
     assertSuccessResponse(response);
     InstitutionsSearchResponse institutionsSearchResponse = response.body();
     assertTrue(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
@@ -92,7 +79,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithoutOAuth() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank").withCountryCodes(Arrays.asList("GB")).withOAuth(false)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("GB"), "Bank").withOAuth(false)).execute();
     assertSuccessResponse(response);
     InstitutionsSearchResponse institutionsSearchResponse = response.body();
     assertFalse(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
@@ -101,7 +88,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testNoResults() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest("zebra")).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "zebra")).execute();
 
     assertSuccessResponse(response);
     assertEquals(0, response.body().getInstitutions().size());

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -21,7 +21,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withProducts(Product.IDENTITY)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest("t", Arrays.asList("US")).withProducts(Product.IDENTITY)).execute();
 
     assertSuccessResponse(response);
   }
@@ -29,7 +29,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataTrue() throws Exception {
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withIncludeOptionalMetadata(true)).execute();
+        client().service().institutionsSearch(new InstitutionsSearchRequest("t", Arrays.asList("US")).withIncludeOptionalMetadata(true)).execute();
 
     assertSuccessResponse(response);
 
@@ -41,7 +41,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithIncludeOptionalMetadataFalse() throws Exception {
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "t").withIncludeOptionalMetadata(false)).execute();
+        client().service().institutionsSearch(new InstitutionsSearchRequest("t", Arrays.asList("US")).withIncludeOptionalMetadata(false)).execute();
 
     assertSuccessResponse(response);
 
@@ -57,7 +57,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
     accountFilter.put("loan", Arrays.asList("student"));
 
     Response<InstitutionsSearchResponse> response =
-        client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "wells")
+        client().service().institutionsSearch(new InstitutionsSearchRequest("wells", Arrays.asList("US"))
           .withAccountFilter(accountFilter)
           .withProducts(Product.LIABILITIES)
         ).execute();
@@ -70,7 +70,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithOAuth() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("GB"), "Bank").withOAuth(true)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank", Arrays.asList("GB")).withOAuth(true)).execute();
     assertSuccessResponse(response);
     InstitutionsSearchResponse institutionsSearchResponse = response.body();
     assertTrue(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
@@ -79,7 +79,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testSuccessWithoutOAuth() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("GB"), "Bank").withOAuth(false)).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Bank", Arrays.asList("GB")).withOAuth(false)).execute();
     assertSuccessResponse(response);
     InstitutionsSearchResponse institutionsSearchResponse = response.body();
     assertFalse(institutionsSearchResponse.getInstitutions().get(0).getOAuth());
@@ -88,7 +88,7 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   @Test
   public void testNoResults() throws Exception {
     Response<InstitutionsSearchResponse> response =
-      client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "zebra")).execute();
+      client().service().institutionsSearch(new InstitutionsSearchRequest("zebra", Arrays.asList("US"))).execute();
 
     assertSuccessResponse(response);
     assertEquals(0, response.body().getInstitutions().size());

--- a/src/test/java/com/plaid/client/integration/PlaidClientTest.java
+++ b/src/test/java/com/plaid/client/integration/PlaidClientTest.java
@@ -6,13 +6,15 @@ import com.plaid.client.response.InstitutionsSearchResponse;
 import org.junit.Test;
 import retrofit2.Response;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 public class PlaidClientTest extends AbstractIntegrationTest {
 
   @Test
   public void testFailedRequest() throws Exception {
-    Response<InstitutionsSearchResponse> resp = client().service().institutionsSearch(new InstitutionsSearchRequest("")).execute();
+    Response<InstitutionsSearchResponse> resp = client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "")).execute();
 
     assertFalse(resp.isSuccessful());
 

--- a/src/test/java/com/plaid/client/integration/PlaidClientTest.java
+++ b/src/test/java/com/plaid/client/integration/PlaidClientTest.java
@@ -14,7 +14,7 @@ public class PlaidClientTest extends AbstractIntegrationTest {
 
   @Test
   public void testFailedRequest() throws Exception {
-    Response<InstitutionsSearchResponse> resp = client().service().institutionsSearch(new InstitutionsSearchRequest(Arrays.asList("US"), "")).execute();
+    Response<InstitutionsSearchResponse> resp = client().service().institutionsSearch(new InstitutionsSearchRequest("", Arrays.asList("US"))).execute();
 
     assertFalse(resp.isSuccessful());
 


### PR DESCRIPTION
Country codes are now required for the /institutions/ API endpoints. This updates the client library to properly take a country_codes field

Note that the institutions tests were already broken for `institution/get_by_id` since we no longer return credential or MFA fields as part of the public institution