### PR TITLE
Fix bank transfer event list test

### DIFF
--- a/src/test/java/com/plaid/client/integration/banktransfer/BankTransferEventListTest.java
+++ b/src/test/java/com/plaid/client/integration/banktransfer/BankTransferEventListTest.java
@@ -2,24 +2,28 @@ package com.plaid.client.integration.banktransfer;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.List;
-
 import com.plaid.client.model.banktransfer.BankTransferEvent;
 import com.plaid.client.request.SandboxBankTransferSimulateRequest;
 import com.plaid.client.request.banktransfer.BankTransferEventListRequest;
 import com.plaid.client.response.SandboxBankTransferSimulateResponse;
 import com.plaid.client.response.banktransfer.BankTransferEventListResponse;
 
+import org.junit.Before;
+import java.util.List;
+
 import retrofit2.Response;
 
 public class BankTransferEventListTest extends AbstractBankTransferTest {
-  @Override
-  protected void bankTransferTest() throws AssertionError, Exception {
+  @Before
+  public void simulatePosted() throws AssertionError, Exception {
     Response<SandboxBankTransferSimulateResponse> simulateResponse = client().service().sandboxBankTransferSimulate(
       new SandboxBankTransferSimulateRequest(getBankTransfer().getId(), "posted")
     ).execute();
     assertSuccessResponse(simulateResponse);
+  }
 
+  @Override
+  protected void bankTransferTest() throws AssertionError, Exception {
     Response<BankTransferEventListResponse> eventListResponse = client().service().bankTransferEventList(
       new BankTransferEventListRequest().withBankTransferId(getBankTransfer().getId())
     ).execute();


### PR DESCRIPTION
Fixes a flaky test issue by excluding non-idempotent function from the retry logic