### PR TITLE
Adds payment_initiation metadata support

### DIFF
--- a/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
@@ -49,26 +49,9 @@ public class InstitutionsGetByIdRequest extends BaseClientRequest {
     return this;
   }
 
-  public InstitutionsGetByIdRequest withPaymentInitiation(PaymentInitiation paymentInitiation) {
-    if (this.options == null) {
-      this.options = new Options();
-    }
-    this.options.paymentInitiation = paymentInitiation;
-    return this;
-  }
-
-  public static class PaymentInitiation {
-    private String paymentId;
-
-    public PaymentInitiation(String paymentId) {
-      this.paymentId = paymentId;
-    }
-  }
-
   private static class Options {
     private boolean includeOptionalMetadata;
     private boolean includeStatus;
     private boolean includePaymentInitiationMetadata;
-    private PaymentInitiation paymentInitiation;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetByIdRequest.java
@@ -41,8 +41,34 @@ public class InstitutionsGetByIdRequest extends BaseClientRequest {
     return this;
   }
 
+  public InstitutionsGetByIdRequest withIncludePaymentInitiationMetadata(boolean includePaymentInitiationMetadata) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.includePaymentInitiationMetadata = includePaymentInitiationMetadata;
+    return this;
+  }
+
+  public InstitutionsGetByIdRequest withPaymentInitiation(PaymentInitiation paymentInitiation) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.paymentInitiation = paymentInitiation;
+    return this;
+  }
+
+  public static class PaymentInitiation {
+    private String paymentId;
+
+    public PaymentInitiation(String paymentId) {
+      this.paymentId = paymentId;
+    }
+  }
+
   private static class Options {
     private boolean includeOptionalMetadata;
     private boolean includeStatus;
+    private boolean includePaymentInitiationMetadata;
+    private PaymentInitiation paymentInitiation;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -53,9 +53,35 @@ public class InstitutionsGetRequest extends BaseClientRequest {
     return this;
   }
 
+  public InstitutionsGetRequest withIncludePaymentInitiationMetadata(boolean includePaymentInitiationMetadata) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.includePaymentInitiationMetadata = includePaymentInitiationMetadata;
+    return this;
+  }
+
+  public InstitutionsGetRequest withPaymentInitiation(PaymentInitiation paymentInitiation) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.paymentInitiation = paymentInitiation;
+    return this;
+  }
+
+  public static class PaymentInitiation {
+    private String paymentId;
+
+    public PaymentInitiation(String paymentId) {
+      this.paymentId = paymentId;
+    }
+  }
+
   private static class Options {
     private List<Product> products;
     private boolean includeOptionalMetadata;
     private Boolean oauth;
+    private boolean includePaymentInitiationMetadata;
+    private PaymentInitiation paymentInitiation;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -61,22 +61,6 @@ public class InstitutionsGetRequest extends BaseClientRequest {
     return this;
   }
 
-  public InstitutionsGetRequest withPaymentInitiation(PaymentInitiation paymentInitiation) {
-    if (this.options == null) {
-      this.options = new Options();
-    }
-    this.options.paymentInitiation = paymentInitiation;
-    return this;
-  }
-
-  public static class PaymentInitiation {
-    private String paymentId;
-
-    public PaymentInitiation(String paymentId) {
-      this.paymentId = paymentId;
-    }
-  }
-
   private static class Options {
     private List<Product> products;
     private boolean includeOptionalMetadata;

--- a/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsGetRequest.java
@@ -66,6 +66,5 @@ public class InstitutionsGetRequest extends BaseClientRequest {
     private boolean includeOptionalMetadata;
     private Boolean oauth;
     private boolean includePaymentInitiationMetadata;
-    private PaymentInitiation paymentInitiation;
   }
 }

--- a/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
+++ b/src/main/java/com/plaid/client/request/InstitutionsSearchRequest.java
@@ -64,9 +64,35 @@ public class InstitutionsSearchRequest extends BaseClientRequest {
     return this;
   }
 
+  public InstitutionsSearchRequest withIncludePaymentInitiationMetadata(boolean includePaymentInitiationMetadata) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.includePaymentInitiationMetadata = includePaymentInitiationMetadata;
+    return this;
+  }
+
+  public InstitutionsSearchRequest withPaymentInitiation(PaymentInitiation paymentInitiation) {
+    if (this.options == null) {
+      this.options = new Options();
+    }
+    this.options.paymentInitiation = paymentInitiation;
+    return this;
+  }
+
+  public static class PaymentInitiation {
+    private String paymentId;
+
+    public PaymentInitiation(String paymentId) {
+      this.paymentId = paymentId;
+    }
+  }
+
   private static class Options {
     private boolean includeOptionalMetadata;
     private Map<String, List<String>> accountFilter;
     private Boolean oauth;
+    private boolean includePaymentInitiationMetadata;
+    private PaymentInitiation paymentInitiation;
   }
 }

--- a/src/main/java/com/plaid/client/response/Institution.java
+++ b/src/main/java/com/plaid/client/response/Institution.java
@@ -4,6 +4,7 @@ import com.plaid.client.request.common.Product;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 
 public class Institution {
   public static class Credential {
@@ -160,6 +161,47 @@ public class Institution {
     }
   }
 
+  public static class StandingOrderMetadata {
+    private boolean supportsStandingOrderEndDate;
+    private boolean supportsStandingOrderNegativeExecutionDays;
+    private List<String> validStandingOrderIntervals;
+
+    public boolean getSupportsStandingOrderEndDate() {
+      return supportsStandingOrderEndDate;
+    }
+
+    public boolean getSupportsStandingOrderNegativeExecutionDays() {
+      return supportsStandingOrderNegativeExecutionDays;
+    }
+
+    public List<String> getValidStandingOrderIntervals() {
+      return validStandingOrderIntervals;
+    }
+  }
+
+  public static class PaymentInitiationMetadata {
+    private StandingOrderMetadata standingOrderMetadata;
+    private Map<String, String> maximumPaymentAmount;
+    private boolean supportsInternationalPayments;
+    private boolean supportsRefundDetails;
+
+    public StandingOrderMetadata getStandingOrderMetadata() {
+      return standingOrderMetadata;
+    }
+
+    public Map<String, String> getMaximumPaymentAmount() {
+      return maximumPaymentAmount;
+    }
+
+    public boolean getSupportsInternationalPayments() {
+      return supportsInternationalPayments;
+    }
+
+    public boolean getSupportsRefundDetails() {
+      return supportsRefundDetails;
+    }
+  }
+
   private List<String> countryCodes;
   private List<Credential> credentials;
   private boolean hasMfa;
@@ -173,6 +215,7 @@ public class Institution {
   private String primaryColor;
   private boolean oauth;
   private List<String> routingNumbers;
+  private PaymentInitiationMetadata paymentInitiationMetadata;
 
   public String getUrl() {
     return url;
@@ -224,5 +267,9 @@ public class Institution {
 
   public List<String> getRoutingNumbers() {
     return routingNumbers;
+  }
+
+  public PaymentInitiationMetadata getPaymentInitiationMetadata() {
+    return paymentInitiationMetadata;
   }
 }

--- a/src/test/java/com/plaid/client/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/plaid/client/integration/AbstractIntegrationTest.java
@@ -29,6 +29,7 @@ public abstract class AbstractIntegrationTest {
   public static final String TATTERSALL_FEDERAL_CREDIT_UNION_INSTITUTION_ID = "ins_109510";
   public static final String TARTAN_BANK_INSTITUTION_ID = "ins_109511";
   public static final String HOUNDSTOOTH_BANK_INSTITUTION_ID = "ins_109512";
+  public static final String ROYAL_BANK_OF_PLAID_INSTITUTION_ID = "ins_117650";
 
   private PlaidClient plaidClient;
   private PlaidSandboxApiService sandboxApiService;

--- a/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsGetByIdTest.java
@@ -92,6 +92,52 @@ public class InstitutionsGetByIdTest extends AbstractIntegrationTest {
     assertIsTartanBank(institution);
   }
 
+  @Test
+  public void testSuccessWithIncludePaymentInitiationMetadataTrue() throws Exception {
+    Response<InstitutionsGetByIdResponse> response =
+      client().service().institutionsGetById(
+        new InstitutionsGetByIdRequest(ROYAL_BANK_OF_PLAID_INSTITUTION_ID, Arrays.asList("GB")).
+        withIncludePaymentInitiationMetadata(true))
+        .execute();
+
+    assertSuccessResponse(response);
+
+    Institution institution = response.body().getInstitution();
+    assertIsRoyalBankOfPlaid(institution);
+
+    assertNotNull(institution.getPaymentInitiationMetadata());
+  }
+
+  @Test
+  public void testSuccessWithIncludePaymentInitiationMetadataFalse() throws Exception {
+    Response<InstitutionsGetByIdResponse> response = client().service().
+      institutionsGetById(new InstitutionsGetByIdRequest(ROYAL_BANK_OF_PLAID_INSTITUTION_ID, Arrays.asList("GB")).
+        withIncludePaymentInitiationMetadata(false))
+      .execute();
+
+    assertSuccessResponse(response);
+
+    Institution institution = response.body().getInstitution();
+    assertIsRoyalBankOfPlaid(institution);
+
+    assertNull(institution.getPaymentInitiationMetadata());
+  }
+
+  private void assertIsRoyalBankOfPlaid(Institution institution) {
+    assertEquals(ROYAL_BANK_OF_PLAID_INSTITUTION_ID, institution.getInstitutionId());
+    assertEquals("Royal Bank of Plaid", institution.getName());
+    assertEquals(Arrays.asList(
+      Product.ASSETS,
+      Product.AUTH,
+      Product.BALANCE,
+      Product.TRANSACTIONS,
+      Product.IDENTITY,
+      Product.PAYMENT_INITIATION
+      ),
+      institution.getProducts());
+    assertTrue(institution.getCountryCodes().contains("GB"));
+  }
+
   private void assertIsTartanBank(Institution institution) {
     assertEquals(TARTAN_BANK_INSTITUTION_ID, institution.getInstitutionId());
     assertEquals("Tartan Bank", institution.getName());

--- a/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
+++ b/src/test/java/com/plaid/client/integration/InstitutionsSearchTest.java
@@ -86,6 +86,24 @@ public class InstitutionsSearchTest extends AbstractIntegrationTest {
   }
 
   @Test
+  public void testSuccessWithIncludePaymentInitiationMetadataTrue() throws Exception {
+    Response<InstitutionsSearchResponse> response = client().service().
+      institutionsSearch(new InstitutionsSearchRequest("Royal Bank of Plaid", Arrays.asList("GB")).withIncludePaymentInitiationMetadata(true)).execute();
+    assertSuccessResponse(response);
+    InstitutionsSearchResponse institutionsSearchResponse = response.body();
+    assertNotNull(institutionsSearchResponse.getInstitutions().get(0).getPaymentInitiationMetadata());
+  }
+
+  @Test
+  public void testSuccessWithIncludePaymentInitiationMetadataFalse() throws Exception {
+    Response<InstitutionsSearchResponse> response =
+      client().service().institutionsSearch(new InstitutionsSearchRequest("Royal Bank of Plaid", Arrays.asList("GB")).withIncludePaymentInitiationMetadata(false)).execute();
+    assertSuccessResponse(response);
+    InstitutionsSearchResponse institutionsSearchResponse = response.body();
+    assertNull(institutionsSearchResponse.getInstitutions().get(0).getPaymentInitiationMetadata());
+  }
+
+  @Test
   public void testNoResults() throws Exception {
     Response<InstitutionsSearchResponse> response =
       client().service().institutionsSearch(new InstitutionsSearchRequest("zebra", Arrays.asList("US"))).execute();


### PR DESCRIPTION
Adds payment_initiation metadata support:
- Returns some more information in the institutions endpoints response.
- Adds in an options parameter to filter institutions by payment id.