### PR TITLE
AccountSubtype.ALL to indicate all subtypes

### DIFF
--- a/src/main/java/com/plaid/client/model/AccountSubtype.java
+++ b/src/main/java/com/plaid/client/model/AccountSubtype.java
@@ -30,6 +30,8 @@ import com.google.gson.stream.JsonWriter;
 @JsonAdapter(AccountSubtype.Adapter.class)
 public enum AccountSubtype {
   
+  ALL("all"),
+  
   _401A("401a"),
   
   _401K("401k"),


### PR DESCRIPTION
To indicate that all subtypes should be shown, use the value "all"

Refer doc: https://plaid.com/docs/api/tokens/#link-token-create-request-account-filters