### PR TITLE
Fix IdentityVerification creation test

### DIFF
--- a/src/test/java/com/plaid/client/integration/IdentityVerificationTest.java
+++ b/src/test/java/com/plaid/client/integration/IdentityVerificationTest.java
@@ -36,7 +36,9 @@ public class IdentityVerificationTest extends AbstractIntegrationTest {
   @Test
   public void testSuccess() throws Exception {
     String customerReference = "idv-user-" + Instant.now();
-    String email = customerReference + "@example.com";
+    // : is not allowed in email addresses but is part of the ISO8601 timestamp format that Instant
+    // is represented as.
+    String email = customerReference.replace(":", "") + "@example.com";
 
     // POST /identity_verification/create
     IdentityVerificationCreateRequestUser user = new IdentityVerificationCreateRequestUser();


### PR DESCRIPTION
- Email validation logic was recently changed slightly to account for issues caused by rare invalid email addresses. This had minimal impact on customers/real data but is incompatible with the `:` that is being generated here. A simple string replace should cause this test to pass.