### PR TITLE
Update gson-fire to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- Plaid generated properties -->
     <swagger-annotations-version>1.5.22</swagger-annotations-version>
     <oltu-version>1.0.1</oltu-version>
-    <gson-fire-version>1.8.3</gson-fire-version>
+    <gson-fire-version>1.9.0</gson-fire-version>
     <javax-annotation-version>1.3.2</javax-annotation-version>
   </properties>
 


### PR DESCRIPTION
This has several bug fixes, and addresses some transitive vulnerabilities (CVE-2022-25647, CVE-2020-15250)